### PR TITLE
Fix navbar text visibility in light mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <html lang="en" suppressHydrationWarning>
         <body className={inter.className}>
           <Providers>
-            <nav className="bg-gray-900 text-gray-900 dark:text-white p-4 shadow mb-6">
+            <nav className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white p-4 shadow mb-6">
               <div className="flex justify-between items-center max-w-7xl mx-auto">
                 <div className="text-xl font-bold">
                   <Link href="/">RentAPrint</Link>


### PR DESCRIPTION
## Summary
- fix navbar classes so the text is readable in light mode

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684cfb83e83883339f895be71fcd6244