### PR TITLE
Fix booking page route params

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { useUser } from '@clerk/nextjs';
 
-export default function BookingPage({ params }: { params: { id: string } }) {
+export default function BookingPage() {
   const router = useRouter();
   const { user } = useUser();
+  const { id } = useParams();
 
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Booking: Runtime Mode</h1>
-      <p className="mb-2">You're booking printer ID: {params.id}</p>
+      <p className="mb-2">You're booking printer ID: {id}</p>
       <div className="mb-4">
         <label className="block mb-1 font-semibold">Estimated Runtime (hours):</label>
         <input


### PR DESCRIPTION
## Summary
- fix the booking page dynamic params usage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfed94a188333bbbdc4cd2b1d4099