### PR TITLE
Add dynamic Patch Notes page

### DIFF
--- a/api/patch-notes/add/route.ts
+++ b/api/patch-notes/add/route.ts
@@ -1,0 +1,20 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const { title, description } = await request.json()
+
+  if (!title || !description) {
+    return new Response('Missing title or description', { status: 400 })
+  }
+
+  const { error } = await supabase.from('patch_notes').insert({ title, description })
+
+  if (error) {
+    console.error('Error inserting patch note', error)
+    return new Response('Failed to add patch note', { status: 500 })
+  }
+
+  return new Response('Patch note added', { status: 200 })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <li><Link href="/bookings">My Bookings</Link></li>
                   <li><Link href="/owner">Owner Panel</Link></li>
                   <li><Link href="/my-printers">My Printers</Link></li>
-                  <li><Link href="/patchnotes">Patch Notes</Link></li>
+                  <li><Link href="/patch-notes">Patch Notes</Link></li>
                   <li><Link href="/profile">Profile</Link></li>
                   <li><ThemeToggle /></li>
                   <SignedIn>

--- a/app/patch-notes/page.tsx
+++ b/app/patch-notes/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+
+interface PatchNote {
+  id: string
+  title: string
+  description: string
+  created_at: string
+}
+
+export default function PatchNotesPage() {
+  const supabase = createClientComponentClient()
+  const [notes, setNotes] = useState<PatchNote[]>([])
+
+  useEffect(() => {
+    const fetchNotes = async () => {
+      const { data, error } = await supabase
+        .from('patch_notes')
+        .select('*')
+        .order('created_at', { ascending: false })
+
+      if (!error && data) {
+        setNotes(data as PatchNote[])
+      } else {
+        console.error('Failed to fetch patch notes', error)
+      }
+    }
+    fetchNotes()
+  }, [])
+
+  return (
+    <main className="p-6 max-w-4xl mx-auto text-gray-900 dark:text-white">
+      <h1 className="text-3xl font-bold mb-6">📘 Patch Notes</h1>
+      {notes.map(note => (
+        <div
+          key={note.id}
+          className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6 border border-gray-300 dark:border-gray-700"
+        >
+          <div className="text-xl font-semibold">{note.title}</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+            {new Date(note.created_at).toLocaleString()}
+          </div>
+          <p>{note.description}</p>
+        </div>
+      ))}
+    </main>
+  )
+}

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -7,3 +7,11 @@ create table if not exists bookings (
   status text default 'pending',
   created_at timestamp with time zone default now()
 );
+
+-- Patch Notes Table
+create table if not exists patch_notes (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text not null,
+  created_at timestamp with time zone default now()
+);

--- a/utils/patchNotes.ts
+++ b/utils/patchNotes.ts
@@ -1,0 +1,7 @@
+export async function logPatchNote(title: string, description: string) {
+  await fetch('/api/patch-notes/add', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, description })
+  })
+}


### PR DESCRIPTION
## Summary
- fetch patch notes from Supabase and render them
- add `patch_notes` table definition
- allow posting new patch notes via `/api/patch-notes/add`
- expose helper `logPatchNote` for posting updates
- link navbar to the new patch notes page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d007efed48333b6521f710acbdffb