### PR TITLE
Remove missing supabase type

### DIFF
--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '@/types/supabase';
 
 export function createClient() {
-  return createClientComponentClient<Database>();
+  return createClientComponentClient();
 }


### PR DESCRIPTION
## Summary
- drop `Database` generic from Supabase client

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0fbadc4483339c1e3e870171b117