### PR TITLE
Fix Supabase imports and improve setup docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # rentaprint
+
 3D printer sharing platform
+
+## Setup
+
+1. Install dependencies with `npm install` (Node.js 18 or higher is recommended).
+2. Copy `.env.example` to `.env.local` and provide your Supabase and Clerk keys:
+   ```bash
+   cp .env.example .env.local
+   ```
+   Edit `.env.local` and replace the placeholder values with the credentials from
+   your Supabase project and Clerk account.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The app will be available at `http://localhost:3000`.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,7 +1,6 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
-import { Database } from '@/types/supabase'
 
 export function createClient() {
-  return createRouteHandlerClient<Database>({ cookies })
+  return createRouteHandlerClient({ cookies })
 }

--- a/lib/updatePrinterStatus.ts
+++ b/lib/updatePrinterStatus.ts
@@ -1,6 +1,7 @@
-import { supabase } from './supabase'
+import { createClient } from './supabase/server'
 
 export async function updatePrinterStatus(printerId: string) {
+  const supabase = createClient()
   const today = new Date().toISOString().split('T')[0]
   const { data: bookings } = await supabase
     .from('bookings')


### PR DESCRIPTION
## Summary
- correct Supabase import for updatePrinterStatus helper
- remove missing Database type from createClient
- document local development and license in the README
- add MIT license file

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d14df6ce0833395e2c5758c569b78