### PR TITLE
Fix Supabase auth in API handlers

### DIFF
--- a/app/api/bookings/cancel/[id]/route.ts
+++ b/app/api/bookings/cancel/[id]/route.ts
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic';
 
 export async function DELETE(request: Request, { params }: { params: { id: string } }) {
   const { userId } = auth();
-  const supabase = createClient();
+  const supabase = await createClient();
 
   if (!userId) return new Response("Unauthorized", { status: 401 });
 

--- a/app/api/patch-notes/add/route.ts
+++ b/app/api/patch-notes/add/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: Request) {
   const { userId } = auth()
   if (!userId) return new Response('Unauthorized', { status: 401 })
 
-  const supabase = createClient()
+  const supabase = await createClient()
   const { title, description } = await request.json()
 
   if (!title || !description) {

--- a/app/api/patch-notes/route.ts
+++ b/app/api/patch-notes/route.ts
@@ -4,7 +4,8 @@ import { cookies } from 'next/headers'
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies })
+  const cookieStore = await cookies()
+  const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
 
   try {
     const { data, error } = await supabase

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
-
-export function createClient() {
-  return createRouteHandlerClient({ cookies })
+export async function createClient() {
+  const cookieStore = await cookies()
+  return createRouteHandlerClient({ cookies: () => cookieStore })
 }


### PR DESCRIPTION
## Summary
- fix Next.js cookie API usage for Supabase
- update bookings cancel route to await client
- update patch notes add route to await client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d212d0dfc833383b68934feaf80d8