### PR TITLE
Improve patch notes UX and seed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,20 @@
    psql "$SUPABASE_URL" < types/schema.sql
    ```
    This defines the `bookings` and `patch_notes` tables used by the app.
-4. Start the development server:
- ```bash
-  npm run dev
-  ```
+4. Insert some example patch notes so the page isn't empty:
+   ```sql
+   insert into patch_notes (title, description)
+   values
+     ('Initial release', 'First public version of RentAPrint'),
+     ('Bug fixes', 'Resolved booking issues and improved printer search.');
+   ```
+   Run this SQL in Supabase or `psql` to seed the table. You can also run
+   `npx ts-node scripts/seed-patch-notes.ts` to insert the same records from the
+   command line.
+5. Start the development server:
+   ```bash
+    npm run dev
+    ```
 
 ## Running tests
 

--- a/__tests__/patch-notes.test.ts
+++ b/__tests__/patch-notes.test.ts
@@ -1,0 +1,23 @@
+import { GET } from '../app/api/patch-notes/route'
+
+jest.mock('@supabase/auth-helpers-nextjs', () => {
+  const mockOrder = jest.fn().mockResolvedValue({ data: [], error: null })
+  const mockSelect = jest.fn(() => ({ order: mockOrder }))
+  const mockFrom = jest.fn(() => ({ select: mockSelect }))
+  return {
+    createRouteHandlerClient: jest.fn(() => ({ from: mockFrom }))
+  }
+})
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => ({}))
+}))
+
+describe('patch notes API', () => {
+  it('returns an array of notes', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body)).toBe(true)
+  })
+})

--- a/app/patch-notes/page.tsx
+++ b/app/patch-notes/page.tsx
@@ -12,6 +12,7 @@ interface PatchNote {
 export default function PatchNotesPage() {
   const [notes, setNotes] = useState<PatchNote[]>([])
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchNotes = async () => {
@@ -27,6 +28,8 @@ export default function PatchNotesPage() {
       } catch (err) {
         console.error('Failed to fetch patch notes', err)
         setErrorMsg('Failed to load patch notes')
+      } finally {
+        setLoading(false)
       }
     }
 
@@ -38,6 +41,12 @@ export default function PatchNotesPage() {
       <h1 className="text-3xl font-bold mb-6">📘 Patch Notes</h1>
       {errorMsg && (
         <p className="text-red-500 mb-4">{errorMsg}</p>
+      )}
+      {loading && (
+        <p className="mb-4">Loading patch notes…</p>
+      )}
+      {!loading && notes.length === 0 && !errorMsg && (
+        <p className="mb-4">No patch notes available.</p>
       )}
       {notes.map(note => (
         <div

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@testing-library/react": "^14.2.1",
     "@testing-library/jest-dom": "^6.2.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1"
   }
 }

--- a/scripts/seed-patch-notes.ts
+++ b/scripts/seed-patch-notes.ts
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js'
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+if (!url || !key) {
+  console.error('Supabase credentials are missing')
+  process.exit(1)
+}
+
+const supabase = createClient(url, key)
+
+async function seed() {
+  const { error } = await supabase.from('patch_notes').insert([
+    { title: 'Initial release', description: 'First public version of RentAPrint' },
+    { title: 'Bug fixes', description: 'Resolved booking issues and improved printer search.' }
+  ])
+
+  if (error) {
+    console.error('Failed to insert patch notes', error)
+  } else {
+    console.log('Patch notes seeded')
+  }
+}
+
+seed()


### PR DESCRIPTION
## Summary
- add loading and empty states to patch notes page
- document seeding patch_notes and add CLI seed script
- include ts-node for running the seed script
- add a Jest test for the patch notes API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d25343c1c83338f681b14a6e9045a