### PR TITLE
Remove patch note form and add sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,14 @@
    psql "$SUPABASE_URL" < types/schema.sql
    ```
    This defines the `bookings` and `patch_notes` tables used by the app.
-4. Insert some example patch notes so the page isn't empty:
-   ```sql
-   insert into patch_notes (title, description)
-   values
-     ('Initial release', 'First public version of RentAPrint'),
-     ('Bug fixes', 'Resolved booking issues and improved printer search.');
+4. Insert some example patch notes so the page isn't empty. Run the sync script
+   to upload the notes from `patch_notes.json`:
+   ```bash
+   npx ts-node scripts/sync-patch-notes.ts
    ```
-   Run this SQL in Supabase or `psql` to seed the table. You can also run
-   `npx ts-node scripts/seed-patch-notes.ts` to insert the same records from the
-   command line.
+   The script reads `patch_notes.json` and inserts any notes that don't already
+   exist in your Supabase database. You can modify the JSON file to add new
+   entries and re-run the script at any time.
 5. Start the development server:
    ```bash
     npm run dev

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest"
+    "test": "jest",
+    "sync:patch-notes": "ts-node scripts/sync-patch-notes.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.21.0",

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "title": "Initial release",
+    "description": "First public version of RentAPrint"
+  },
+  {
+    "title": "Bug fixes",
+    "description": "Resolved booking issues and improved printer search."
+  }
+]

--- a/scripts/sync-patch-notes.ts
+++ b/scripts/sync-patch-notes.ts
@@ -1,0 +1,47 @@
+import { createClient } from '@supabase/supabase-js'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+if (!url || !key) {
+  console.error('Supabase credentials are missing')
+  process.exit(1)
+}
+
+const supabase = createClient(url, key)
+
+async function sync() {
+  const filePath = path.join(process.cwd(), 'patch_notes.json')
+  const file = await fs.readFile(filePath, 'utf-8')
+  const notes = JSON.parse(file)
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('patch_notes')
+    .select('title')
+
+  if (fetchError) {
+    console.error('Failed to fetch existing patch notes', fetchError)
+    process.exit(1)
+  }
+
+  const existingTitles = new Set(existing?.map(n => n.title))
+  const newNotes = notes.filter((n: { title: string }) => !existingTitles.has(n.title))
+
+  if (newNotes.length === 0) {
+    console.log('No new patch notes to add')
+    return
+  }
+
+  const { error } = await supabase.from('patch_notes').insert(newNotes)
+
+  if (error) {
+    console.error('Failed to insert patch notes', error)
+    process.exit(1)
+  }
+
+  console.log(`Inserted ${newNotes.length} patch note(s)`)
+}
+
+sync()


### PR DESCRIPTION
## Summary
- revert patch note submission form
- add CLI script `sync-patch-notes.ts` to upload notes from `patch_notes.json`
- document script usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d28c5dbc48333b5f2aff4f9e76a65