### PR TITLE
Update booking auth

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { useUser } from '@clerk/nextjs'
 import type { Printer } from '@/lib/data'
 
 export default function BookingPage() {
   const { id } = useParams()
   const router = useRouter()
   const supabase = createClientComponentClient()
+  const { user } = useUser()
   const [printer, setPrinter] = useState<Printer | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -30,9 +32,6 @@ export default function BookingPage() {
   }, [id])
 
   const handleBooking = async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
     if (!user) {
       alert('You must be logged in to book a printer.')
       return


### PR DESCRIPTION
## Summary
- use Clerk's `useUser` hook in booking page
- simplify booking auth check

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3213990c8333928ec555af256ea6