### PR TITLE
Fix server auth imports

### DIFF
--- a/app/api/bookings/cancel/[id]/route.ts
+++ b/app/api/bookings/cancel/[id]/route.ts
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = 'force-dynamic';

--- a/app/api/patch-notes/add/route.ts
+++ b/app/api/patch-notes/add/route.ts
@@ -1,4 +1,4 @@
-import { auth } from '@clerk/nextjs'
+import { auth } from '@clerk/nextjs/server'
 import { createClient } from '@/lib/supabase/server'
 
 export const dynamic = 'force-dynamic'


### PR DESCRIPTION
## Summary
- fix server-side auth imports in cancel booking and patch note API routes

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d33428a0c833392b53fb100c27b3b