### PR TITLE
Fix bookings cancellation auth

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -25,7 +25,10 @@ export default function BookingsPage() {
   }, [user, supabase]);
 
   const cancelBooking = async (bookingId: string) => {
-    const res = await fetch(`/api/bookings/cancel/${bookingId}`, { method: 'DELETE' });
+    const res = await fetch(`/api/bookings/cancel/${bookingId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
     if (res.ok) {
       alert("Booking canceled ✅");
       setBookings(bookings.filter(b => b.id !== bookingId));


### PR DESCRIPTION
## Summary
- include cookies when calling the cancel booking API to prevent 401

## Testing
- `npm test` *(fails: jest not found)*
- `npm run dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3bc3334c8333a3e06aaf6add0217