### PR TITLE
Fix patch notes API cookies usage

### DIFF
--- a/app/api/patch-notes/route.ts
+++ b/app/api/patch-notes/route.ts
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers'
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
 
   try {


### PR DESCRIPTION
## Summary
- await `cookies()` in the patch notes API route to avoid runtime errors

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d3e05febc8333914e609feb42a221