### PR TITLE
Add user printer management page

### DIFF
--- a/app/api/printers/delete/[id]/route.ts
+++ b/app/api/printers/delete/[id]/route.ts
@@ -1,0 +1,29 @@
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const { userId } = auth();
+  const supabase = await createClient();
+
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { error, data } = await supabase
+    .from('printers')
+    .delete()
+    .eq('id', params.id)
+    .eq('clerk_user_id', userId)
+    .select();
+
+  if (error) {
+    console.error('Error deleting printer', error);
+    return new Response(`Failed to delete printer: ${error.message}`, { status: 500 });
+  }
+
+  if (!data || data.length === 0) {
+    return new Response('Printer not found', { status: 404 });
+  }
+
+  return new Response('Printer deleted', { status: 200 });
+}

--- a/app/my-printers/page.tsx
+++ b/app/my-printers/page.tsx
@@ -1,9 +1,134 @@
-'use client';
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  useUser,
+} from "@clerk/nextjs";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Printer } from "@/lib/data";
+
 export default function MyPrinters() {
+  const { user } = useUser();
+  const supabase = createClientComponentClient();
+  const [printers, setPrinters] = useState<Printer[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPrinters = async () => {
+      const { data, error } = await supabase
+        .from("printers")
+        .select("*")
+        .eq("clerk_user_id", user?.id);
+      if (error) console.error("Error fetching printers", error);
+      setPrinters(data || []);
+      setLoading(false);
+    };
+
+    if (user?.id) fetchPrinters();
+  }, [user, supabase]);
+
+  const deletePrinter = async (id: string) => {
+    if (!confirm("Delete this printer?")) return;
+    const res = await fetch(`/api/printers/delete/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (res.ok) {
+      setPrinters(printers.filter((p) => p.id !== id));
+    } else {
+      alert("Failed to delete printer");
+    }
+  };
+
+  const printerCards = (
+    <div className="grid gap-4">
+      {printers.map((printer) => (
+        <div
+          key={printer.id}
+          className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded shadow p-4 space-y-2"
+        >
+          <div className="flex justify-between items-start">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {printer.name}
+            </h2>
+            {printer.status && (
+              <span
+                className={`text-xs font-semibold px-2 py-1 rounded ${{
+                  available: "bg-green-600 text-gray-900 dark:text-white",
+                  pending: "bg-yellow-500 text-black",
+                  rented: "bg-red-600 text-gray-900 dark:text-white",
+                }[printer.status]}`}
+              >
+                {printer.status}
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            ${printer.price_per_hour}/hr &bull; {printer.build_volume}
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Materials: {printer.materials?.join(", ")}
+          </p>
+          <div className="flex gap-2 flex-wrap pt-2">
+            <Link
+              href="/owner/bookings"
+              className="px-3 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+            >
+              View Bookings
+            </Link>
+            <Link
+              href={`/my-printers/${printer.id}/edit`}
+              className="px-3 py-1 text-sm bg-yellow-400 text-black rounded hover:bg-yellow-500"
+            >
+              Edit
+            </Link>
+            <button
+              onClick={() => deletePrinter(printer.id)}
+              className="px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-gray-900 dark:text-white rounded"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  const emptyState = (
+    <div className="space-y-2 text-gray-900 dark:text-white">
+      <p>You haven\'t listed any printers yet.</p>
+      <Link
+        href="/new-listing"
+        className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+      >
+        Create New Listing
+      </Link>
+    </div>
+  );
+
+  const content = loading ? (
+    <p className="text-center p-8 text-gray-900 dark:text-white">Loading printers...</p>
+  ) : printers.length === 0 ? (
+    emptyState
+  ) : (
+    printerCards
+  );
+
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-4">My Printers</h1>
-      <p>You haven't listed any printers yet. More tools for managing your printers coming soon!</p>
-    </main>
+    <>
+      <SignedIn>
+        <main className="max-w-4xl mx-auto p-6 space-y-4">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Printers</h1>
+          {content}
+        </main>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- implement a real `/my-printers` page to manage printer listings
- add API route to allow deleting printers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1f1345c8333b06a372d0b1f70c0