### PR TITLE
Update patch notes data with ids and timestamps

### DIFF
--- a/app/api/patch-notes/route.ts
+++ b/app/api/patch-notes/route.ts
@@ -1,5 +1,7 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
+import { promises as fs } from 'fs'
+import path from 'path'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,6 +10,30 @@ export async function GET() {
   const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
 
   try {
+    // ensure database has any new notes from the JSON file
+    const filePath = path.join(process.cwd(), 'patch_notes.json')
+    const file = await fs.readFile(filePath, 'utf-8')
+    const fileNotes: { id: string; title: string; description: string; created_at: string }[] = JSON.parse(file)
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('patch_notes')
+      .select('id')
+
+    if (fetchError) {
+      console.error('Error fetching existing patch notes', fetchError)
+      return new Response('Failed to fetch patch notes', { status: 500 })
+    }
+
+    const existingIds = new Set(existing?.map(n => n.id))
+    const newNotes = fileNotes.filter(n => !existingIds.has(n.id))
+
+    if (newNotes.length > 0) {
+      const { error: insertError } = await supabase.from('patch_notes').insert(newNotes)
+      if (insertError) {
+        console.error('Failed to insert new patch notes', insertError)
+      }
+    }
+
     const { data, error } = await supabase
       .from('patch_notes')
       .select('*')

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -1,14 +1,38 @@
 [
   {
-    "title": "Initial release",
-    "description": "First public version of RentAPrint"
-  },
-  {
-    "title": "Bug fixes",
-    "description": "Resolved booking issues and improved printer search."
-  },
-  {
+    "id": "af9ce1d7-d105-4eca-9a02-6ee1b425ea99",
     "title": "Major updates",
-    "description": "Improved booking cancellation errors, cleaned duplicate components, clarified test instructions, and fixed environment example."
+    "description": "Improved booking cancellation errors, cleaned duplicate components, clarified test instructions, and fixed environment example.",
+    "created_at": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "5777d4b1-f16b-4160-ad0f-011b48ca9621",
+    "title": "Initial Release",
+    "description": "First public version of RentAPrint",
+    "created_at": "2025-06-14T02:43:02.000Z"
+  },
+  {
+    "id": "1b0ae62f-961f-4eee-94f5-d8d558c9a3e2",
+    "title": "Bug Fixes",
+    "description": "Resolved booking issues and improved printer search.",
+    "created_at": "2025-06-14T02:43:02.000Z"
+  },
+  {
+    "id": "207900e9-1a1f-4c9b-8b3e-380fb7ee28bc",
+    "title": "Owner Panel Page",
+    "description": "Added a fully functional Owner Panel page with printer and booking summaries.",
+    "created_at": "2025-06-14T02:44:00.000Z"
+  },
+  {
+    "id": "1d80e8a5-a980-4d19-9678-0a39e4939d72",
+    "title": "My Printers Page",
+    "description": "Built the My Printers page, allowing users to view, edit, delete, and manage their printer listings.",
+    "created_at": "2025-06-14T02:45:00.000Z"
+  },
+  {
+    "id": "43acb14c-7639-4204-af1a-bc0a122ab13a",
+    "title": "Profile Page",
+    "description": "Populated the Profile page with user details, account actions, printer/bookings stats, and upcoming bookings display.",
+    "created_at": "2025-06-14T02:46:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- add patch notes with unique UUIDs and ISO timestamps
- sync Supabase with `patch_notes.json` whenever `/api/patch-notes` is called

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dda0241448333bbfba76c71e48cde