### PR TITLE
Add booking runtime management

### DIFF
--- a/app/api/bookings/delete/[id]/route.ts
+++ b/app/api/bookings/delete/[id]/route.ts
@@ -1,0 +1,29 @@
+import { auth } from "@clerk/nextjs/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = 'force-dynamic';
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const { userId } = auth();
+  const supabase = await createClient();
+
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { error, data } = await supabase
+    .from('bookings')
+    .delete()
+    .eq('id', params.id)
+    .eq('clerk_user_id', userId)
+    .select();
+
+  if (error) {
+    console.error('Error deleting booking', error);
+    return new Response(`Failed to delete booking: ${error.message}`, { status: 500 });
+  }
+
+  if (!data || data.length === 0) {
+    return new Response('Booking not found', { status: 404 });
+  }
+
+  return new Response('Booking deleted', { status: 200 });
+}

--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -13,6 +13,7 @@ export default function BookingPage() {
   const { user } = useUser()
   const [printer, setPrinter] = useState<Printer | null>(null)
   const [loading, setLoading] = useState(true)
+  const [runtime, setRuntime] = useState(1)
 
   useEffect(() => {
     const fetchPrinter = async () => {
@@ -37,12 +38,15 @@ export default function BookingPage() {
       return
     }
 
+    const start = new Date()
+    const end = new Date(start.getTime() + runtime * 3600 * 1000)
     const { error } = await supabase.from('bookings').insert({
       printer_id: id,
       clerk_user_id: user.id,
       status: 'pending',
-      start_date: new Date().toISOString(),
-      end_date: new Date(Date.now() + 3600 * 1000).toISOString(),
+      start_date: start.toISOString(),
+      end_date: end.toISOString(),
+      estimated_runtime_hours: runtime,
     })
 
     if (error) {
@@ -83,6 +87,22 @@ export default function BookingPage() {
       <p>
         <strong>Make/Model:</strong> {printer.make_model || 'N/A'}
       </p>
+      <div className="pt-2 space-y-2">
+        <label className="block text-sm">
+          Estimated Runtime (hrs):
+          <input
+            type="number"
+            step="0.1"
+            min="0"
+            value={runtime}
+            onChange={e => setRuntime(parseFloat(e.target.value))}
+            className="mt-1 w-full p-2 border rounded text-black dark:text-white dark:bg-neutral-800"
+          />
+        </label>
+        <p className="text-sm">
+          Estimated Cost: ${'{'}(runtime * (printer.price_per_hour || 0)).toFixed(2){'}'}
+        </p>
+      </div>
       <button
         onClick={handleBooking}
         className="mt-4 px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded hover:bg-blue-700"

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -37,6 +37,19 @@ export default function BookingsPage() {
     }
   };
 
+  const deleteBooking = async (bookingId: string) => {
+    if (!confirm('Delete this booking?')) return;
+    const res = await fetch(`/api/bookings/delete/${bookingId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (res.ok) {
+      setBookings(bookings.filter(b => b.id !== bookingId));
+    } else {
+      alert('Failed to delete booking ❌');
+    }
+  };
+
   if (loading) return <p className="text-center p-8 text-gray-900 dark:text-white">Loading bookings...</p>;
 
   return (
@@ -56,6 +69,7 @@ export default function BookingsPage() {
                 className={`text-xs font-semibold px-2 py-1 rounded ${{
                   pending: 'bg-yellow-400 text-black',
                   approved: 'bg-green-600 text-gray-900 dark:text-white',
+                  complete: 'bg-blue-600 text-gray-900 dark:text-white',
                   canceled: 'bg-red-600 text-gray-900 dark:text-white',
                 }[booking.status] || 'bg-gray-300 text-black'}`}
               >
@@ -72,12 +86,22 @@ export default function BookingsPage() {
               >
                 View Printer
               </a>
-              <button
-                onClick={() => cancelBooking(booking.id)}
-                className="px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-gray-900 dark:text-white rounded"
-              >
-                Cancel Booking
-              </button>
+              {['pending', 'approved'].includes(booking.status) && (
+                <button
+                  onClick={() => cancelBooking(booking.id)}
+                  className="px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-gray-900 dark:text-white rounded"
+                >
+                  Cancel Booking
+                </button>
+              )}
+              {booking.status === 'canceled' && (
+                <button
+                  onClick={() => deleteBooking(booking.id)}
+                  className="px-3 py-1 text-sm bg-gray-500 hover:bg-gray-600 text-white rounded"
+                >
+                  Delete Booking
+                </button>
+              )}
             </div>
           </div>
         ))

--- a/app/owner/components/OwnerPanelClient.tsx
+++ b/app/owner/components/OwnerPanelClient.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import Link from 'next/link'
+import { SignedIn, SignedOut, RedirectToSignIn, useUser } from '@clerk/nextjs'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import type { Printer } from '@/lib/data'
+
+interface Booking {
+  id: string
+  clerk_user_id: string
+  start_date: string
+  end_date: string
+  status: string
+  estimated_runtime_hours?: number
+  actual_runtime_hours?: number
+  printers: {
+    name: string
+  }
+}
+
+export default function OwnerPanel() {
+  const { user } = useUser()
+  const supabase = useMemo(() => createClientComponentClient(), [])
+
+  const [printers, setPrinters] = useState<Printer[]>([])
+  const [bookings, setBookings] = useState<Booking[]>([])
+  const [loadingPrinters, setLoadingPrinters] = useState(true)
+  const [loadingBookings, setLoadingBookings] = useState(true)
+  const [runtimeModal, setRuntimeModal] = useState<{ id: string } | null>(null)
+  const [actualRuntime, setActualRuntime] = useState('')
+
+  const submitRuntime = async () => {
+    if (!runtimeModal) return
+    const { error } = await supabase
+      .from('bookings')
+      .update({ actual_runtime_hours: parseFloat(actualRuntime), status: 'complete' })
+      .eq('id', runtimeModal.id)
+
+    if (error) {
+      alert('Failed to set runtime')
+      console.error(error)
+    } else {
+      setBookings(
+        bookings.map(b =>
+          b.id === runtimeModal.id ? { ...b, status: 'complete', actual_runtime_hours: parseFloat(actualRuntime) } : b
+        )
+      )
+    }
+    setActualRuntime('')
+    setRuntimeModal(null)
+  }
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data: printerData, error: printerError } = await supabase
+        .from('printers')
+        .select('*')
+        .eq('clerk_user_id', user?.id)
+
+      if (printerError) console.error('Error fetching printers:', printerError)
+      setPrinters(printerData || [])
+      setLoadingPrinters(false)
+
+      if (printerData && printerData.length > 0) {
+        const ids = printerData.map((p) => p.id)
+        const { data: bookingData, error: bookingError } = await supabase
+          .from('bookings')
+          .select('id, clerk_user_id, start_date, end_date, status, estimated_runtime_hours, actual_runtime_hours, printers(name)')
+          .in('printer_id', ids)
+          .order('start_date', { ascending: false })
+
+        if (bookingError) console.error('Error fetching bookings:', bookingError)
+        setBookings(bookingData || [])
+      }
+      setLoadingBookings(false)
+    }
+
+    if (user?.id) fetchData()
+  }, [user])
+
+  const printerList = (
+    <section>
+      <h2 className="text-xl font-semibold mb-2">Your Printers</h2>
+      {loadingPrinters ? (
+        <p>Loading printers...</p>
+      ) : printers.length === 0 ? (
+        <p>You have no printers listed yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {printers.map((printer) => (
+            <li
+              key={printer.id}
+              className="p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+            >
+              <div>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {printer.name}
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Status: {printer.status || 'available'} &bull; ${' '}
+                  {printer.price_per_hour}/hr
+                </p>
+              </div>
+              <button className="px-3 py-1 text-sm bg-yellow-400 text-black rounded hover:bg-yellow-500">
+                Edit
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+
+  const bookingList = (
+    <section>
+      <h2 className="text-xl font-semibold mb-2">Recent Bookings</h2>
+      {loadingBookings ? (
+        <p>Loading bookings...</p>
+      ) : bookings.length === 0 ? (
+        <p>No bookings for your printers yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {bookings.map((booking) => {
+            const start = new Date(booking.start_date)
+            const end = new Date(booking.end_date)
+            const hours = Math.round((end.getTime() - start.getTime()) / 3600000)
+            const now = new Date()
+            const active = booking.status === 'approved' && start <= now && end >= now
+            return (
+              <li
+                key={booking.id}
+                className="p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-white space-y-1"
+              >
+                <div className="flex items-center justify-between">
+                  <p className="font-medium">{booking.printers.name}</p>
+                  <span
+                    className={`text-xs font-semibold px-2 py-1 rounded ${{
+                      pending: 'bg-yellow-400 text-black',
+                      approved: 'bg-green-600 text-gray-900 dark:text-white',
+                      complete: 'bg-blue-600 text-gray-900 dark:text-white',
+                      canceled: 'bg-red-600 text-gray-900 dark:text-white',
+                    }[booking.status]}`}
+                  >
+                    {booking.status}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Renter: {booking.clerk_user_id}
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Start: {start.toLocaleString()}
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Est: {booking.estimated_runtime_hours ?? hours} hrs
+                  {booking.actual_runtime_hours && ` • Actual: ${booking.actual_runtime_hours} hrs`}
+                </p>
+                {active && (
+                  <button
+                    onClick={() => setRuntimeModal({ id: booking.id })}
+                    className="mt-2 px-3 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+                  >
+                    Set Final Runtime
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+
+  return (
+    <>
+      <SignedIn>
+        <main className="space-y-8 p-4">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold">Owner Panel</h1>
+            <Link
+              href="/printers/new"
+              className="px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded hover:bg-blue-700"
+            >
+              Create New Listing
+            </Link>
+          </div>
+          {printerList}
+          {bookingList}
+        </main>
+        {runtimeModal && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white dark:bg-gray-800 p-4 rounded space-y-3">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Set Final Runtime</h3>
+              <input
+                type="number"
+                step="0.1"
+                min="0"
+                value={actualRuntime}
+                onChange={e => setActualRuntime(e.target.value)}
+                className="w-full p-2 border rounded text-black dark:text-white dark:bg-neutral-800"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setRuntimeModal(null)}
+                  className="px-3 py-1 text-sm bg-gray-500 text-white rounded"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={submitRuntime}
+                  className="px-3 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  )
+}

--- a/app/owner/page.tsx
+++ b/app/owner/page.tsx
@@ -1,147 +1,17 @@
-'use client'
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import dynamic from 'next/dynamic'
 
-import { useEffect, useState, useMemo } from 'react'
-import Link from 'next/link'
-import { SignedIn, SignedOut, RedirectToSignIn, useUser } from '@clerk/nextjs'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Printer } from '@/lib/data'
+const OwnerPanel = dynamic(() => import('./components/OwnerPanelClient'), { ssr: false })
 
-interface Booking {
-  id: string
-  clerk_user_id: string
-  start_date: string
-  end_date: string
-  printers: {
-    name: string
+export default async function OwnerPage() {
+  const { userId } = auth()
+  if (!userId) redirect('/')
+  const supabase = await createClient()
+  const { data } = await supabase.from('printers').select('id').eq('clerk_user_id', userId)
+  if (!data || data.length === 0) {
+    return <div className="p-6 text-gray-900 dark:text-white">Not Authorized</div>
   }
-}
-
-export default function OwnerPanel() {
-  const { user } = useUser()
-  const supabase = useMemo(() => createClientComponentClient(), [])
-
-  const [printers, setPrinters] = useState<Printer[]>([])
-  const [bookings, setBookings] = useState<Booking[]>([])
-  const [loadingPrinters, setLoadingPrinters] = useState(true)
-  const [loadingBookings, setLoadingBookings] = useState(true)
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: printerData, error: printerError } = await supabase
-        .from('printers')
-        .select('*')
-        .eq('clerk_user_id', user?.id)
-
-      if (printerError) console.error('Error fetching printers:', printerError)
-      setPrinters(printerData || [])
-      setLoadingPrinters(false)
-
-      if (printerData && printerData.length > 0) {
-        const ids = printerData.map((p) => p.id)
-        const { data: bookingData, error: bookingError } = await supabase
-          .from('bookings')
-          .select('id, clerk_user_id, start_date, end_date, printers(name)')
-          .in('printer_id', ids)
-          .order('start_date', { ascending: false })
-
-        if (bookingError) console.error('Error fetching bookings:', bookingError)
-        setBookings(bookingData || [])
-      }
-      setLoadingBookings(false)
-    }
-
-    if (user?.id) fetchData()
-  }, [user])
-
-  const printerList = (
-    <section>
-      <h2 className="text-xl font-semibold mb-2">Your Printers</h2>
-      {loadingPrinters ? (
-        <p>Loading printers...</p>
-      ) : printers.length === 0 ? (
-        <p>You have no printers listed yet.</p>
-      ) : (
-        <ul className="space-y-3">
-          {printers.map((printer) => (
-            <li
-              key={printer.id}
-              className="p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
-            >
-              <div>
-                <p className="font-medium text-gray-900 dark:text-white">
-                  {printer.name}
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Status: {printer.status || 'available'} &bull; ${' '}
-                  {printer.price_per_hour}/hr
-                </p>
-              </div>
-              <button className="px-3 py-1 text-sm bg-yellow-400 text-black rounded hover:bg-yellow-500">
-                Edit
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
-  )
-
-  const bookingList = (
-    <section>
-      <h2 className="text-xl font-semibold mb-2">Recent Bookings</h2>
-      {loadingBookings ? (
-        <p>Loading bookings...</p>
-      ) : bookings.length === 0 ? (
-        <p>No bookings for your printers yet.</p>
-      ) : (
-        <ul className="space-y-3">
-          {bookings.map((booking) => {
-            const start = new Date(booking.start_date)
-            const end = new Date(booking.end_date)
-            const hours = Math.round((end.getTime() - start.getTime()) / 3600000)
-            return (
-              <li
-                key={booking.id}
-                className="p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded text-gray-900 dark:text-white"
-              >
-                <p className="font-medium">{booking.printers.name}</p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Renter: {booking.clerk_user_id}
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Start: {start.toLocaleString()}
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Duration: {hours} hrs
-                </p>
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </section>
-  )
-
-  return (
-    <>
-      <SignedIn>
-        <main className="space-y-8 p-4">
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold">Owner Panel</h1>
-            <Link
-              href="/printers/new"
-              className="px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded hover:bg-blue-700"
-            >
-              Create New Listing
-            </Link>
-          </div>
-          {printerList}
-          {bookingList}
-        </main>
-      </SignedIn>
-      <SignedOut>
-        <RedirectToSignIn />
-      </SignedOut>
-    </>
-  )
+  return <OwnerPanel />
 }

--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -7,12 +7,30 @@ import type { Printer } from '@/lib/data';
 
 export default function PrintersPage() {
   const [printers, setPrinters] = useState<Printer[]>([]);
+  const [rented, setRented] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     const fetchPrinters = async () => {
       const supabase = createPagesBrowserClient();
       const { data } = await supabase.from('printers').select('*');
       setPrinters(data || []);
+      const ids = data?.map((p: any) => p.id) || [];
+      if (ids.length > 0) {
+        const { data: bookings } = await supabase
+          .from('bookings')
+          .select('printer_id,start_date,end_date,status')
+          .in('printer_id', ids);
+        const now = new Date();
+        const map: Record<string, boolean> = {};
+        bookings?.forEach(b => {
+          const start = new Date(b.start_date as string);
+          const end = new Date(b.end_date as string);
+          if (b.status === 'approved' && start <= now && end >= now) {
+            map[b.printer_id as string] = true;
+          }
+        });
+        setRented(map);
+      }
     };
     fetchPrinters();
   }, []);
@@ -22,7 +40,14 @@ export default function PrintersPage() {
       <h2 className="text-2xl font-bold mb-4">Available Printers</h2>
       <div className="flex flex-col gap-4 items-start">
         {printers.map((printer) => (
-          <PrinterCard key={printer.id} printer={printer} />
+          <div key={printer.id} className="relative">
+            <PrinterCard printer={printer} />
+            {rented[printer.id] && (
+              <span className="absolute inset-0 bg-black/50 text-white flex items-center justify-center font-semibold pointer-events-none rounded">
+                Currently Rented
+              </span>
+            )}
+          </div>
         ))}
       </div>
     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -8,6 +8,7 @@ interface Booking {
   id: string
   start_date: string
   end_date: string
+  status?: string
   printers: { name: string }
 }
 
@@ -53,7 +54,7 @@ export default function ProfilePage() {
     const loadUpcoming = async () => {
       const { data } = await supabase
         .from('bookings')
-        .select('id, start_date, end_date, printers(name)')
+        .select('id, start_date, end_date, status, printers(name)')
         .eq('clerk_user_id', user.id)
         .gt('start_date', new Date().toISOString())
         .order('start_date', { ascending: true })
@@ -127,8 +128,18 @@ export default function ProfilePage() {
                   const start = new Date(b.start_date)
                   const hours = Math.round((new Date(b.end_date).getTime() - start.getTime()) / 3600000)
                   return (
-                    <li key={b.id} className="p-4 bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-white">
-                      <p className="font-medium">{b.printers?.name}</p>
+                    <li key={b.id} className="p-4 bg-gray-100 dark:bg-gray-700 rounded text-gray-900 dark:text-white space-y-1">
+                      <div className="flex items-center justify-between">
+                        <p className="font-medium">{b.printers?.name}</p>
+                        {b.status && (
+                          <span className={`text-xs font-semibold px-2 py-1 rounded ${{
+                            pending: 'bg-yellow-400 text-black',
+                            approved: 'bg-green-600 text-gray-900 dark:text-white',
+                            complete: 'bg-blue-600 text-gray-900 dark:text-white',
+                            canceled: 'bg-red-600 text-gray-900 dark:text-white',
+                          }[b.status]}`}>{b.status}</span>
+                        )}
+                      </div>
                       <p className="text-sm">Start: {start.toLocaleString()}</p>
                       <p className="text-sm">Duration: {hours} hrs</p>
                     </li>

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -7,6 +7,8 @@ create table if not exists bookings (
   clerk_user_id text,
   start_date timestamp with time zone,
   end_date timestamp with time zone,
+  estimated_runtime_hours numeric,
+  actual_runtime_hours numeric,
   status text default 'pending',
   created_at timestamp with time zone default now()
 );


### PR DESCRIPTION
## Summary
- add booking deletion API
- support estimated runtime during booking
- show runtime and status in owner panel with modal to set final runtime
- overlay rented printers on listings
- show booking status in profile/bookings pages
- restrict owner page server-side
- extend bookings schema with runtime fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de4d520788333b92f4745b0d5135a