### PR TITLE
Fix patch-notes tests and correct printer price display

### DIFF
--- a/__tests__/patch-notes.test.ts
+++ b/__tests__/patch-notes.test.ts
@@ -3,7 +3,8 @@ import { GET } from '../app/api/patch-notes/route'
 jest.mock('@supabase/auth-helpers-nextjs', () => {
   const mockOrder = jest.fn().mockResolvedValue({ data: [], error: null })
   const mockSelect = jest.fn(() => ({ order: mockOrder }))
-  const mockFrom = jest.fn(() => ({ select: mockSelect }))
+  const mockInsert = jest.fn().mockResolvedValue({ error: null })
+  const mockFrom = jest.fn(() => ({ select: mockSelect, insert: mockInsert }))
   return {
     createRouteHandlerClient: jest.fn(() => ({ from: mockFrom }))
   }

--- a/app/my-printers/page.tsx
+++ b/app/my-printers/page.tsx
@@ -86,7 +86,7 @@ export default function MyPrinters() {
             )}
           </div>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            ${printer.price_per_hour}/hr &bull; {printer.build_volume}
+            {printer.price_per_hour}/hr &bull; {printer.build_volume}
           </p>
           <p className="text-sm text-gray-600 dark:text-gray-400">
             Materials: {printer.materials?.join(", ")}


### PR DESCRIPTION
## Summary
- extend Supabase mock in `patch-notes` tests to support `insert`
- render price per hour correctly on the My Printers page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de7671d44833383f686c2c5602611