### PR TITLE
Add license and contribution docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+- Be respectful and constructive.
+- Refrain from discriminatory or harassing behavior.
+- Respect differing viewpoints and experiences.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards and may take
+appropriate and fair corrective action in response to any behavior that they
+deem inappropriate.
+
+## Scope
+
+This Code of Conduct applies within project spaces and in public spaces when an
+individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the maintainers at `support@rentaprint.net`.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to RentAPrint
+
+Thank you for your interest in contributing! We welcome issues and pull requests.
+
+## Development Setup
+
+1. Install dependencies with `npm install`.
+2. Copy `.env.example` to `.env.local` and update the values for your Supabase project.
+3. Run the SQL in `types/schema.sql` to create the required tables.
+4. Start the development server with `npm run dev`.
+5. Run the tests with `npm test` before submitting changes.
+
+## Coding Standards
+
+- Use TypeScript.
+- Keep formatting consistent with the existing code base.
+- Include tests for new features when possible.
+
+## Pull Requests
+
+1. Fork the repository and create your feature branch.
+2. Commit your changes with clear messages.
+3. Open a pull request against `main` describing your changes.
+4. Ensure all tests pass.
+
+### Sample Codex Prompt
+
+```
+Add a feature to allow users to upload printer photos via drag and drop.
+```
+
+We encourage opening issues first if you're planning large changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,19 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2024
+Parameters
+========= 
+License: Business Source License 1.1 (BSL-1.1)
+Licensor: RentAPrint
+Licensed Work: The RentAPrint project
+Additional Use Grant: Any use that is not for commercial purposes
+Change Date: 2026-06-30
+Change License: MIT
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Terms
+=====
+The Licensed Work is subject to the terms of the Business Source License 1.1.
+Usage is permitted only for non-commercial purposes, unless a commercial
+license is obtained from the Licensor or until the Change Date, after which
+the Work becomes available under the Change License.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+See https://mariadb.com/bsl11 for the full license text.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,47 @@
-# rentaprint
+# RentAPrint
 
-3D printer sharing platform
+RentAPrint is an open-source platform for sharing and booking 3D printers.
+It allows printer owners to list their devices and makers to book time on
+printers near them. The official hosted service is available at
+[https://rentaprint.net](https://rentaprint.net).
 
-## Setup
+## Local Development
 
-1. Install dependencies with `npm install` (Node.js 18 or higher is recommended).
-2. Copy `.env.example` to `.env.local`:
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example environment file:
    ```bash
    cp .env.example .env.local
    ```
-3. Create the database tables. Run the SQL in `types/schema.sql` against your
-   Supabase project using the SQL editor or `psql`:
-   ```bash
-   psql "$SUPABASE_URL" < types/schema.sql
-   ```
-   This defines the `bookings`, `patch_notes`, and `reviews` tables used by the app.
-4. Insert some example patch notes so the page isn't empty. Run the sync script
-   to upload the notes from `patch_notes.json`:
+3. Create the database tables by running the SQL in `types/schema.sql` against
+   your Supabase project.
+4. Insert example patch notes:
    ```bash
    npx ts-node scripts/sync-patch-notes.ts
    ```
-   The script reads `patch_notes.json` and inserts any notes that don't already
-   exist in your Supabase database. You can modify the JSON file to add new
-   entries and re-run the script at any time.
-5. Start the development server:
+5. Start the dev server:
    ```bash
-    npm run dev
-    ```
-
-## Running tests
-
-Install dependencies first to ensure Jest and other dev tools are available:
-
-```bash
-npm install
-```
-
-Then run the test suite with:
-
-```bash
-npm test
-```
+   npm run dev
+   ```
 
 The app will be available at `http://localhost:3000`.
 
+## Monetization Policy
+
+Self‑hosting is allowed for personal use. **Commercial use requires a separate
+license** or is permitted once the project transitions to the MIT license two
+years after each release.
+
+## Contributing
+
+We welcome pull requests and issue reports! See
+[CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines.
+Codex users can help by submitting patches, documentation improvements and
+new feature ideas.
+
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is released under the Business Source License 1.1. See
+[LICENSE](LICENSE) for details.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Providers>
             <Navbar />
             <main className="max-w-7xl mx-auto p-4">{children}</main>
+            <footer className="text-center text-sm text-gray-500 py-4">
+              Open source by RentAPrint. Powered by the community. Visit{' '}
+              <a href="https://rentaprint.net" className="underline">
+                rentaprint.net
+              </a>{' '}for the official version.
+            </footer>
           </Providers>
         </body>
       </html>


### PR DESCRIPTION
## Summary
- switch to Business Source License 1.1 with non‑commercial clause
- document setup and monetization policy in README
- add contributing guidelines and code of conduct
- display open source notice in the site footer

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fc8a6dc6c83338c522f0d2d63a7e2