### PR TITLE
Fix import path for cancel booking route

### DIFF
--- a/app/api/bookings/cancel/[id]/route.ts
+++ b/app/api/bookings/cancel/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 interface Params {
   params: {


### PR DESCRIPTION
## Summary
- correct the Supabase utility path for the cancel booking API route

## Testing
- No tests were run as per instructions

------
https://chatgpt.com/codex/tasks/task_e_684fd7910c188333acb7a70043ef9267