### PR TITLE
Fix Supabase import path for cancel booking API

### DIFF
--- a/app/api/bookings/cancel/[id]/route.ts
+++ b/app/api/bookings/cancel/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '../../../utils/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types';
 
 export async function DELETE(req: NextRequest, context: RouteHandlerContext) {


### PR DESCRIPTION
## Summary
- fix wrong path to supabase client in booking cancellation route

## Testing
- `npm run build` *(fails: Type error in bookings/delete route)*

------
https://chatgpt.com/codex/tasks/task_e_684fda5c35308333ab624bac420f5db1