### PR TITLE
Fix DELETE API route types

### DIFF
--- a/app/api/bookings/delete/[id]/route.ts
+++ b/app/api/bookings/delete/[id]/route.ts
@@ -1,29 +1,31 @@
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from 'next/server'
+import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types'
 
 export const dynamic = 'force-dynamic';
 
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, context: RouteHandlerContext) {
   const { userId } = auth();
   const supabase = createClient();
 
-  if (!userId) return new Response("Unauthorized", { status: 401 });
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { error, data } = await supabase
     .from('bookings')
     .delete()
-    .eq('id', params.id)
+    .eq('id', context.params.id)
     .eq('clerk_user_id', userId)
     .select();
 
   if (error) {
     console.error('Error deleting booking', error);
-    return new Response(`Failed to delete booking: ${error.message}`, { status: 500 });
+    return NextResponse.json({ error: `Failed to delete booking: ${error.message}` }, { status: 500 });
   }
 
   if (!data || data.length === 0) {
-    return new Response('Booking not found', { status: 404 });
+    return NextResponse.json({ error: 'Booking not found' }, { status: 404 });
   }
 
-  return new Response('Booking deleted', { status: 200 });
+  return NextResponse.json({ message: 'Booking deleted' }, { status: 200 });
 }

--- a/app/api/printers/delete/[id]/route.ts
+++ b/app/api/printers/delete/[id]/route.ts
@@ -1,29 +1,31 @@
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from 'next/server'
+import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types'
 
 export const dynamic = 'force-dynamic';
 
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, context: RouteHandlerContext) {
   const { userId } = auth();
   const supabase = createClient();
 
-  if (!userId) return new Response("Unauthorized", { status: 401 });
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { error, data } = await supabase
     .from('printers')
     .delete()
-    .eq('id', params.id)
+    .eq('id', context.params.id)
     .eq('clerk_user_id', userId)
     .select();
 
   if (error) {
     console.error('Error deleting printer', error);
-    return new Response(`Failed to delete printer: ${error.message}`, { status: 500 });
+    return NextResponse.json({ error: `Failed to delete printer: ${error.message}` }, { status: 500 });
   }
 
   if (!data || data.length === 0) {
-    return new Response('Printer not found', { status: 404 });
+    return NextResponse.json({ error: 'Printer not found' }, { status: 404 });
   }
 
-  return new Response('Printer deleted', { status: 200 });
+  return NextResponse.json({ message: 'Printer deleted' }, { status: 200 });
 }


### PR DESCRIPTION
## Summary
- use `NextRequest` and `RouteHandlerContext` for DELETE handlers
- return `NextResponse.json` in DELETE handlers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe020f7588333bc1fa4a03789c742