### PR TITLE
Inline DELETE route param types

### DIFF
--- a/app/api/bookings/cancel/[id]/route.ts
+++ b/app/api/bookings/cancel/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types';
 
-export async function DELETE(req: NextRequest, context: RouteHandlerContext) {
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const supabase = createClient();
-  const bookingId = context.params.id;
+  const bookingId = params.id;
 
   const { error } = await supabase.from('bookings').delete().eq('id', bookingId);
 

--- a/app/api/bookings/delete/[id]/route.ts
+++ b/app/api/bookings/delete/[id]/route.ts
@@ -1,11 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from 'next/server'
-import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types'
 
 export const dynamic = 'force-dynamic';
 
-export async function DELETE(request: NextRequest, context: RouteHandlerContext) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const { userId } = auth();
   const supabase = createClient();
 
@@ -14,7 +16,7 @@ export async function DELETE(request: NextRequest, context: RouteHandlerContext)
   const { error, data } = await supabase
     .from('bookings')
     .delete()
-    .eq('id', context.params.id)
+    .eq('id', params.id)
     .eq('clerk_user_id', userId)
     .select();
 

--- a/app/api/printers/delete/[id]/route.ts
+++ b/app/api/printers/delete/[id]/route.ts
@@ -1,11 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from 'next/server'
-import type { RouteHandlerContext } from 'next/dist/server/future/route-modules/app-route/types'
 
 export const dynamic = 'force-dynamic';
 
-export async function DELETE(request: NextRequest, context: RouteHandlerContext) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const { userId } = auth();
   const supabase = createClient();
 
@@ -14,7 +16,7 @@ export async function DELETE(request: NextRequest, context: RouteHandlerContext)
   const { error, data } = await supabase
     .from('printers')
     .delete()
-    .eq('id', context.params.id)
+    .eq('id', params.id)
     .eq('clerk_user_id', userId)
     .select();
 


### PR DESCRIPTION
## Summary
- stop importing RouteHandlerContext from internal Next.js path
- inline types for `params` object in DELETE route handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe32873f08333b69297aee8f09f2c