### PR TITLE
Fix estimated cost rendering on booking page

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function BookingPage() {
           />
         </label>
         <p className="text-sm">
-          Estimated Cost: ${'{'}(runtime * (printer.price_per_hour || 0)).toFixed(2){'}'}
+          {`Estimated Cost: $${(runtime * (printer.price_per_hour || 0)).toFixed(2)}`}
         </p>
       </div>
       <button


### PR DESCRIPTION
## Summary
- render runtime cost correctly on printer booking page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffbc16ad083339ec9f4a3e16d3a9b