### PR TITLE
Fix missing estimated_runtime_hours docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ service is available at [rentaprint.net](https://rentaprint.net).
    ```bash
    cp .env.example .env.local
    ```
-3. Create the database tables by running the SQL in `types/schema.sql` against
-   your Supabase project.
+3. Create **or update** the database tables by running the SQL in `types/schema.sql`
+   against your Supabase project. Whenever you pull new code, re-run this file to
+   apply any schema changes (for example new columns like `estimated_runtime_hours`).
 4. Insert example patch notes:
    ```bash
    npx ts-node scripts/sync-patch-notes.ts


### PR DESCRIPTION
## Summary
- clarify database migration instructions in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685067f82578833395a5f01660f7cced