### PR TITLE
Fix booking status type

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -2,11 +2,12 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { bookingStatusClasses, type BookingStatus } from '@/lib/bookings';
 
 interface Booking {
   id: string
   printer_id: string
-  status: string
+  status: BookingStatus
   created_at: string
   clerk_user_id: string
   start_date: string
@@ -77,14 +78,9 @@ export default function BookingsPage() {
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold">{booking.printers.name}</h2>
               <span
-                className={`text-xs font-semibold px-2 py-1 rounded ${{
-                  pending: 'bg-yellow-400 text-black',
-                  approved: 'bg-green-600 text-gray-900 dark:text-white',
-                  rejected: 'bg-red-600 text-gray-900 dark:text-white',
-                  in_progress: 'bg-blue-500 text-gray-900 dark:text-white',
-                  completed: 'bg-blue-600 text-gray-900 dark:text-white',
-                  canceled: 'bg-red-600 text-gray-900 dark:text-white',
-                }[booking.status as keyof any] || 'bg-gray-300 text-black'}`}
+                className={`text-xs font-semibold px-2 py-1 rounded ${
+                  bookingStatusClasses[booking.status] || 'bg-gray-300 text-black'
+                }`}
               >
                 {booking.status}
               </span>
@@ -102,7 +98,9 @@ export default function BookingsPage() {
               >
                 View Printer
               </a>
-              {['pending', 'approved'].includes(booking.status) && (
+              {(['pending', 'approved'] as BookingStatus[]).includes(
+                booking.status
+              ) && (
                 <button
                   onClick={() => cancelBooking(booking.id)}
                   className="px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-gray-900 dark:text-white rounded"

--- a/app/owner/components/OwnerPanelClient.tsx
+++ b/app/owner/components/OwnerPanelClient.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link'
 import { SignedIn, SignedOut, RedirectToSignIn, useUser } from '@clerk/nextjs'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import type { Printer } from '@/lib/data'
+import { bookingStatusClasses, type BookingStatus } from '@/lib/bookings'
 
 interface Booking {
   id: string
   printer_id: string
   clerk_user_id: string
-  status: string
+  status: BookingStatus
   created_at: string
   start_date: string
   end_date: string
@@ -42,7 +43,7 @@ export default function OwnerPanel() {
     }
   }
 
-  const updateStatus = async (id: string, status: string) => {
+  const updateStatus = async (id: string, status: BookingStatus) => {
     const { error } = await supabase.from('bookings').update({ status }).eq('id', id)
     if (error) {
       alert('Failed to update booking')
@@ -149,14 +150,9 @@ export default function OwnerPanel() {
                         <li key={booking.id} className="p-3 border rounded bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white space-y-1">
                           <div className="flex justify-between items-center">
                             <p className="font-medium">{Array.isArray(booking.printers) ? booking.printers[0]?.name : booking.printers.name}</p>
-                            <span className={`text-xs font-semibold px-2 py-1 rounded ${{
-                                pending: 'bg-yellow-400 text-black',
-                                approved: 'bg-green-600 text-gray-900 dark:text-white',
-                                rejected: 'bg-red-600 text-gray-900 dark:text-white',
-                                in_progress: 'bg-blue-500 text-gray-900 dark:text-white',
-                                completed: 'bg-blue-600 text-gray-900 dark:text-white',
-                                canceled: 'bg-red-600 text-gray-900 dark:text-white',
-                              }[booking.status as keyof any]}`}>{booking.status}</span>
+                            <span className={`text-xs font-semibold px-2 py-1 rounded ${
+                                bookingStatusClasses[booking.status]
+                              }`}>{booking.status}</span>
                           </div>
                           <p className="text-xs text-gray-600 dark:text-gray-400">Booked {new Date(booking.created_at).toLocaleString()}</p>
                           <p className="text-sm text-gray-600 dark:text-gray-400">Renter: {booking.clerk_user_id}</p>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -3,11 +3,12 @@
 import { useEffect, useState, useMemo } from 'react'
 import { SignedIn, SignedOut, RedirectToSignIn, useUser, UserButton, useClerk } from '@clerk/nextjs'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { bookingStatusClasses, type BookingStatus } from '@/lib/bookings'
 
 interface Booking {
   id: string
   printer_id?: string
-  status?: string
+  status?: BookingStatus
   created_at?: string
   start_date: string
   end_date: string
@@ -138,14 +139,9 @@ export default function ProfilePage() {
                         : b.printers?.name}
                     </p>
                     {b.status && (
-                      <span className={`text-xs font-semibold px-2 py-1 rounded ${{
-                        pending: 'bg-yellow-400 text-black',
-                        approved: 'bg-green-600 text-gray-900 dark:text-white',
-                        rejected: 'bg-red-600 text-gray-900 dark:text-white',
-                        in_progress: 'bg-blue-500 text-gray-900 dark:text-white',
-                        completed: 'bg-blue-600 text-gray-900 dark:text-white',
-                        canceled: 'bg-red-600 text-gray-900 dark:text-white',
-                      }[b.status as keyof any]}`}>{b.status}</span>
+                      <span className={`text-xs font-semibold px-2 py-1 rounded ${
+                        bookingStatusClasses[b.status]
+                      }`}>{b.status}</span>
                     )}
                   </div>
                   {b.created_at && (

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,0 +1,16 @@
+export type BookingStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'in_progress'
+  | 'completed'
+  | 'canceled';
+
+export const bookingStatusClasses: Record<BookingStatus, string> = {
+  pending: 'bg-yellow-400 text-black',
+  approved: 'bg-green-600 text-gray-900 dark:text-white',
+  rejected: 'bg-red-600 text-gray-900 dark:text-white',
+  in_progress: 'bg-blue-500 text-gray-900 dark:text-white',
+  completed: 'bg-blue-600 text-gray-900 dark:text-white',
+  canceled: 'bg-red-600 text-gray-900 dark:text-white',
+};


### PR DESCRIPTION
## Summary
- add `bookingStatusClasses` and `BookingStatus` helper
- type booking status across pages and use helper map

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850971da6c883339ba77948d92c0c47