### PR TITLE
Implement printer soft delete

### DIFF
--- a/app/api/printers/delete/[id]/route.ts
+++ b/app/api/printers/delete/[id]/route.ts
@@ -16,7 +16,7 @@ export async function DELETE(
 
   const { error, data } = await supabase
     .from('printers')
-    .delete()
+    .update({ is_deleted: true })
     .eq('id', params.id)
     .eq('clerk_user_id', userId)
     .select();

--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -21,6 +21,7 @@ export default function BookingPage() {
         .from('printers')
         .select('*')
         .eq('id', id)
+        .eq('is_deleted', false)
         .single()
       if (error) {
         console.error('Error fetching printer:', error)

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -26,7 +26,8 @@ export default function BookingsPage() {
       const { data, error } = await supabase
         .from('bookings')
         .select('*, printers(*)')
-        .eq('clerk_user_id', user?.id);
+        .eq('clerk_user_id', user?.id)
+        .eq('printers.is_deleted', false);
 
       if (error) console.error(error);
       else setBookings(data || []);

--- a/app/my-printers/[id]/edit/page.tsx
+++ b/app/my-printers/[id]/edit/page.tsx
@@ -18,7 +18,12 @@ export default function EditPrinterPage() {
 
   useEffect(() => {
     async function fetchPrinter() {
-      const { data } = await supabase.from('printers').select('*').eq('id', id).single()
+      const { data } = await supabase
+        .from('printers')
+        .select('*')
+        .eq('id', id)
+        .eq('is_deleted', false)
+        .single()
       if (data) {
         setForm({
           name: data.name,

--- a/app/my-printers/page.tsx
+++ b/app/my-printers/page.tsx
@@ -23,7 +23,8 @@ export default function MyPrinters() {
       const { data, error } = await supabase
         .from("printers")
         .select("*")
-        .eq("clerk_user_id", user?.id);
+        .eq("clerk_user_id", user?.id)
+        .eq('is_deleted', false);
       if (error) console.error("Error fetching printers", error);
       setPrinters(data || []);
       setLoading(false);

--- a/app/owner/components/OwnerPanelClient.tsx
+++ b/app/owner/components/OwnerPanelClient.tsx
@@ -79,6 +79,7 @@ export default function OwnerPanel() {
         .from('printers')
         .select('*')
         .eq('clerk_user_id', user?.id)
+        .eq('is_deleted', false)
 
       if (printerError)
         console.error(
@@ -95,6 +96,7 @@ export default function OwnerPanel() {
           .from('bookings')
           .select('id, printer_id, status, created_at, clerk_user_id, start_date, end_date, estimated_runtime_hours, actual_runtime_hours, printers(name)')
           .in('printer_id', ids)
+          .eq('printers.is_deleted', false)
           .order('start_date', { ascending: false })
 
         if (bookingError)

--- a/app/owner/page.tsx
+++ b/app/owner/page.tsx
@@ -7,7 +7,11 @@ export default async function OwnerPage() {
   const { userId } = await auth()
   if (!userId) redirect('/')
   const supabase = createClient()
-  const { data } = await supabase.from('printers').select('id').eq('clerk_user_id', userId)
+  const { data } = await supabase
+    .from('printers')
+    .select('id')
+    .eq('clerk_user_id', userId)
+    .eq('is_deleted', false)
   if (!data || data.length === 0) {
     return <div className="p-6 text-gray-900 dark:text-white">Not Authorized</div>
   }

--- a/app/printers/[id]/page.tsx
+++ b/app/printers/[id]/page.tsx
@@ -14,7 +14,12 @@ export default function PrinterDetailPage() {
 
   useEffect(() => {
     const fetchPrinter = async () => {
-      const { data: printerData } = await supabase.from('printers').select('*').eq('id', id).single();
+      const { data: printerData } = await supabase
+        .from('printers')
+        .select('*')
+        .eq('id', id)
+        .eq('is_deleted', false)
+        .single();
       const { data: bookings } = await supabase
         .from('bookings')
         .select('start_date, end_date, status')

--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -15,7 +15,8 @@ export default function PrintersPage() {
       const { data } = await supabase
         .from('printers')
         .select('*')
-        .eq('is_available', true);
+        .eq('is_available', true)
+        .eq('is_deleted', false);
       setPrinters(data || []);
       const ids = data?.map((p: any) => p.id) || [];
       if (ids.length > 0) {

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -33,6 +33,7 @@ export default function ProfilePage() {
         .from('printers')
         .select('*', { count: 'exact', head: true })
         .eq('clerk_user_id', user.id)
+        .eq('is_deleted', false)
 
       const { data: bookingData, count: bookingCount } = await supabase
         .from('bookings')
@@ -59,6 +60,7 @@ export default function ProfilePage() {
         .from('bookings')
         .select('id, printer_id, status, created_at, start_date, end_date, printers(name)')
         .eq('clerk_user_id', user.id)
+        .eq('printers.is_deleted', false)
         .gt('start_date', new Date().toISOString())
         .order('start_date', { ascending: true })
 

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -14,6 +14,7 @@ create table if not exists bookings (
 
 -- Printers table update
 alter table printers add column if not exists is_available boolean default true;
+alter table printers add column if not exists is_deleted boolean default false;
 
 -- Patch Notes Table
 create table if not exists patch_notes (


### PR DESCRIPTION
## Summary
- add new `is_deleted` column to Supabase schema
- update printer deletion API to soft-delete
- filter out deleted printers on listing, booking, and owner pages
- exclude deleted printers when counting or loading bookings

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68509fae28508333a07c0b5a9656a765