### PR TITLE
Fix view for deleted printers

### DIFF
--- a/app/printers/[id]/page.tsx
+++ b/app/printers/[id]/page.tsx
@@ -18,8 +18,7 @@ export default function PrinterDetailPage() {
         .from('printers')
         .select('*')
         .eq('id', id)
-        .eq('is_deleted', false)
-        .single();
+        .single(); // Do not filter out soft-deleted printers here
       const { data: bookings } = await supabase
         .from('bookings')
         .select('start_date, end_date, status')
@@ -57,7 +56,12 @@ export default function PrinterDetailPage() {
   return (
     <div className="p-6 text-gray-900 dark:text-white max-w-xl space-y-2">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{printer.name}</h1>
+        <h1 className="text-2xl font-bold">
+          {printer.name}{' '}
+          {printer.is_deleted && (
+            <span className="text-sm text-red-400">(This printer has been deleted)</span>
+          )}
+        </h1>
         <span className={`text-gray-900 dark:text-white text-xs px-2 py-1 rounded ${statusColors[status as keyof typeof statusColors]}`}>
           {status}
         </span>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,4 +12,5 @@ export interface Printer {
   description: string | null
   status?: string
   is_available?: boolean
+  is_deleted?: boolean
 }

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -46,5 +46,11 @@
     "title": "Owner Management Improvements",
     "description": "Added printer availability controls and booking status management for owners.",
     "created_at": "2025-06-16T21:57:30.000Z"
+  },
+  {
+    "id": "31bab597-f36c-4def-99f2-e92f9d4e306b",
+    "title": "Fix View Deleted Printers",
+    "description": "Viewing a soft-deleted printer no longer hangs and now shows a deleted label.",
+    "created_at": "2025-06-16T22:20:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- fetch single printer without is_deleted filter
- display deleted label when viewing removed printers
- include is_deleted in Printer type
- add patch note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a8696cec833385cec9292cbcfc5f