### PR TITLE
Fix owner panel auth when printers missing

### DIFF
--- a/app/owner/page.tsx
+++ b/app/owner/page.tsx
@@ -1,19 +1,32 @@
 import { auth } from '@clerk/nextjs/server'
-import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import Link from 'next/link'
 import OwnerPanel from './components/OwnerPanelClient'
 
 export default async function OwnerPage() {
-  const { userId } = await auth()
-  if (!userId) redirect('/')
+  const { userId, sessionId } = await auth()
   const supabase = createClient()
-  const { data } = await supabase
+
+  if (!sessionId && !userId) {
+    return <p>Not Authorized</p>
+  }
+
+  const { data: printers } = await supabase
     .from('printers')
     .select('id')
     .eq('clerk_user_id', userId)
     .eq('is_deleted', false)
-  if (!data || data.length === 0) {
-    return <div className="p-6 text-gray-900 dark:text-white">Not Authorized</div>
+
+  if (!printers || printers.length === 0) {
+    return (
+      <div className="p-6 text-gray-900 dark:text-white">
+        <p>You don’t have any printers listed yet. Add one to get started.</p>
+        <Link href="/new-listing">
+          <button className="bg-blue-600 text-white px-4 py-2 rounded mt-4">Create New Listing</button>
+        </Link>
+      </div>
+    )
   }
+
   return <OwnerPanel />
 }

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -59,4 +59,11 @@
     "description": "Implemented soft delete for printers, preserved historical bookings and visibility, fixed \"Unknown Printer\" display, allowed viewing deleted printers, and hid the booking button for deleted listings.",
     "created_at": "2025-06-16T22:45:00.000Z"
   }
+  ,
+  {
+    "id": "1125df0b-772a-43e4-aa73-003902c00379",
+    "title": "Owner Panel Authorization Fix",
+    "description": "Resolved \"Not Authorized\" message when owners had no printers and added helpful prompt to create a new listing.",
+    "created_at": "2025-06-17T00:00:00.000Z"
+  }
 ]


### PR DESCRIPTION
## Summary
- fix owner panel logic for empty printer list
- show create listing link when no printers exist
- update patch notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b0d4634483338317324f7450f924