### PR TITLE
Add printers empty state

### DIFF
--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -42,18 +42,25 @@ export default function PrintersPage() {
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">Available Printers</h2>
-      <div className="flex flex-col gap-4 items-start">
-        {printers.map((printer) => (
-          <div key={printer.id} className="relative">
-            <PrinterCard printer={printer} />
-            {rented[printer.id] && (
-              <span className="absolute inset-0 bg-black/50 text-white flex items-center justify-center font-semibold pointer-events-none rounded">
-                Currently Rented
-              </span>
-            )}
-          </div>
-        ))}
-      </div>
+      {printers.length === 0 ? (
+        <div className="text-center mt-10 text-gray-400 flex flex-col items-center">
+          <span className="text-6xl mb-2">🖨️</span>
+          <p>No printers available yet. Check back soon!</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 items-start">
+          {printers.map(printer => (
+            <div key={printer.id} className="relative">
+              <PrinterCard printer={printer} />
+              {rented[printer.id] && (
+                <span className="absolute inset-0 bg-black/50 text-white flex items-center justify-center font-semibold pointer-events-none rounded">
+                  Currently Rented
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -58,12 +58,17 @@
     "title": "Soft Delete Support",
     "description": "Implemented soft delete for printers, preserved historical bookings and visibility, fixed \"Unknown Printer\" display, allowed viewing deleted printers, and hid the booking button for deleted listings.",
     "created_at": "2025-06-16T22:45:00.000Z"
-  }
-  ,
+  },
   {
     "id": "1125df0b-772a-43e4-aa73-003902c00379",
     "title": "Owner Panel Authorization Fix",
     "description": "Resolved \"Not Authorized\" message when owners had no printers and added helpful prompt to create a new listing.",
     "created_at": "2025-06-17T00:00:00.000Z"
+  },
+  {
+    "id": "e8d25b1b-98f3-4ccd-8b3a-9dba3a0c2119",
+    "title": "Printers Empty State",
+    "description": "Added a friendly message on the printers page when no listings are available.",
+    "created_at": "2025-06-17T00:12:18.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- show an empty-state message on `/printers`
- record the change in `patch_notes.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b2a597f883338f4f8987247f0c64