### PR TITLE
Add printer maintenance mode

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -34,6 +34,10 @@ export default function BookingPage() {
   }, [id])
 
   const handleBooking = async () => {
+    if (printer?.is_under_maintenance) {
+      alert('This printer is currently under maintenance and cannot be booked.')
+      return
+    }
     if (!user) {
       alert('You must be logged in to book a printer.')
       return
@@ -97,6 +101,9 @@ export default function BookingPage() {
       <p>
         <strong>Make/Model:</strong> {printer.make_model || 'N/A'}
       </p>
+      {printer.is_under_maintenance && (
+        <p className="text-red-500 mt-2">This printer is under maintenance.</p>
+      )}
       <div className="pt-2 space-y-2">
         <label className="block text-sm">
           Estimated Runtime (hrs):
@@ -115,7 +122,8 @@ export default function BookingPage() {
       </div>
       <button
         onClick={handleBooking}
-        className="mt-4 px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded hover:bg-blue-700"
+        disabled={printer.is_under_maintenance}
+        className="mt-4 px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded hover:bg-blue-700 disabled:opacity-50"
       >
         Confirm Booking
       </button>

--- a/app/owner/components/OwnerPanelClient.tsx
+++ b/app/owner/components/OwnerPanelClient.tsx
@@ -43,6 +43,20 @@ export default function OwnerPanel() {
     }
   }
 
+  const toggleMaintenance = async (id: string, current: boolean) => {
+    const { error } = await supabase
+      .from('printers')
+      .update({ is_under_maintenance: !current })
+      .eq('id', id)
+    if (error) {
+      alert('Failed to update maintenance status')
+    } else {
+      setPrinters(printers.map(p => (
+        p.id === id ? { ...p, is_under_maintenance: !current } : p
+      )))
+    }
+  }
+
   const updateStatus = async (id: string, status: BookingStatus) => {
     const { error } = await supabase.from('bookings').update({ status }).eq('id', id)
     if (error) {
@@ -139,6 +153,9 @@ export default function OwnerPanel() {
                     <Link href={`/my-printers/${printer.id}/edit`} className="px-3 py-1 text-sm bg-yellow-400 text-black rounded hover:bg-yellow-500">Edit</Link>
                     <button onClick={() => toggleAvailability(printer.id, printer.is_available ?? true)} className="px-3 py-1 text-sm bg-gray-300 dark:bg-gray-600 text-black dark:text-white rounded hover:bg-gray-400 dark:hover:bg-gray-500">
                       {printer.is_available ? 'Set Unavailable' : 'Set Available'}
+                    </button>
+                    <button onClick={() => toggleMaintenance(printer.id, printer.is_under_maintenance ?? false)} className="px-3 py-1 text-sm bg-gray-300 dark:bg-gray-600 text-black dark:text-white rounded hover:bg-gray-400 dark:hover:bg-gray-500">
+                      {printer.is_under_maintenance ? 'End Maintenance' : 'Start Maintenance'}
                     </button>
                   </div>
                 </div>

--- a/app/printers/[id]/page.tsx
+++ b/app/printers/[id]/page.tsx
@@ -71,7 +71,10 @@ export default function PrinterDetailPage() {
       <p><strong>Max Print Size:</strong> {printer.build_volume}</p>
       <p><strong>Rate:</strong> ${printer.price_per_hour}/hr</p>
       <p><strong>Description:</strong> {printer.description}</p>
-      {!printer.is_deleted ? (
+      {printer.is_under_maintenance && (
+        <p className="text-red-500 mt-2">This printer is under maintenance.</p>
+      )}
+      {!printer.is_deleted && !printer.is_under_maintenance ? (
         <Link
           href={`/book/${printer.id}`}
           className="inline-block mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
@@ -83,7 +86,7 @@ export default function PrinterDetailPage() {
           disabled
           className="inline-block mt-4 px-4 py-2 bg-gray-400 text-white rounded cursor-not-allowed"
         >
-          Booking Unavailable (Deleted Printer)
+          Booking Unavailable
         </button>
       )}
     </div>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -13,4 +13,5 @@ export interface Printer {
   status?: string
   is_available?: boolean
   is_deleted?: boolean
+  is_under_maintenance?: boolean
 }

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "05a8860e-aa28-43a0-949e-b2456483874c",
+    "title": "Printer Maintenance Mode",
+    "description": "- Owners can mark printers as under maintenance.\n- Bookings are blocked when a printer is under maintenance.\n- Maintenance status is shown on printer pages.",
+    "created_at": "2025-06-18T00:00:00.000Z"
+  },
+  {
     "id": "1125df0b-772a-43e4-aa73-003902c00379",
     "title": "Owner Panel & Empty State UX",
     "description": "- Resolved 'Not Authorized' message when owners had no printers.\n- Added prompt to create a new listing.\n- Added friendly message on the printers page when no listings are available.",

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -15,6 +15,7 @@ create table if not exists bookings (
 -- Printers table update
 alter table printers add column if not exists is_available boolean default true;
 alter table printers add column if not exists is_deleted boolean default false;
+alter table printers add column if not exists is_under_maintenance boolean default false;
 
 -- Patch Notes Table
 create table if not exists patch_notes (


### PR DESCRIPTION
## Summary
- introduce maintenance mode field to DB schema
- expose `is_under_maintenance` in `Printer` type
- allow owners to toggle maintenance in Owner Panel
- block booking when a printer is under maintenance
- show maintenance notice on printer detail page
- log update in patch notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c9be00388333be4fe170490e6b61