### PR TITLE
Add runtime limits for bookings

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -47,6 +47,18 @@ export default function BookingPage() {
       alert('Please enter a valid runtime in hours.')
       return
     }
+    if (
+      printer &&
+      (runtime < (printer.min_runtime_hours ?? 1) ||
+        runtime > (printer.max_runtime_hours ?? 24))
+    ) {
+      alert(
+        `Please enter a runtime between ${
+          printer.min_runtime_hours ?? 1
+        } and ${printer.max_runtime_hours ?? 24} hours.`
+      )
+      return
+    }
 
     const start = new Date()
     const end = new Date(start.getTime() + runtime * 3600 * 1000)
@@ -116,6 +128,11 @@ export default function BookingPage() {
             className="mt-1 w-full p-2 border rounded text-black dark:text-white dark:bg-neutral-800"
           />
         </label>
+        <p className="text-sm">
+          {`Runtime must be between ${printer.min_runtime_hours ?? 1} and ${
+            printer.max_runtime_hours ?? 24
+          } hours.`}
+        </p>
         <p className="text-sm">
           {`Estimated Cost: $${(runtime * (printer.price_per_hour || 0)).toFixed(2)}`}
         </p>

--- a/app/my-printers/[id]/edit/page.tsx
+++ b/app/my-printers/[id]/edit/page.tsx
@@ -13,6 +13,8 @@ export default function EditPrinterPage() {
     materials: '',
     buildVolume: '',
     pricePerHour: '',
+    minRuntime: '',
+    maxRuntime: '',
     description: ''
   })
 
@@ -30,6 +32,8 @@ export default function EditPrinterPage() {
           materials: data.materials.join(', '),
           buildVolume: data.build_volume,
           pricePerHour: data.price_per_hour.toString(),
+          minRuntime: (data.min_runtime_hours ?? '').toString(),
+          maxRuntime: (data.max_runtime_hours ?? '').toString(),
           description: data.description
         })
       }
@@ -50,6 +54,8 @@ export default function EditPrinterPage() {
       materials: form.materials.split(',').map(m => m.trim()),
       build_volume: form.buildVolume,
       price_per_hour: parseFloat(form.pricePerHour),
+      min_runtime_hours: form.minRuntime ? parseFloat(form.minRuntime) : null,
+      max_runtime_hours: form.maxRuntime ? parseFloat(form.maxRuntime) : null,
       description: form.description
     }).eq('id', id)
 
@@ -65,6 +71,8 @@ export default function EditPrinterPage() {
         <input name="materials" value={form.materials} onChange={handleChange} placeholder="Materials (comma separated)" className="w-full p-2 border rounded" required />
         <input name="buildVolume" value={form.buildVolume} onChange={handleChange} placeholder="Build Volume (e.g. 220x220x250mm)" className="w-full p-2 border rounded" required />
         <input name="pricePerHour" value={form.pricePerHour} onChange={handleChange} placeholder="Price per Hour ($)" type="number" step="0.01" className="w-full p-2 border rounded" required />
+        <input name="minRuntime" value={form.minRuntime} onChange={handleChange} placeholder="Min Runtime Hours" type="number" className="w-full p-2 border rounded" />
+        <input name="maxRuntime" value={form.maxRuntime} onChange={handleChange} placeholder="Max Runtime Hours" type="number" className="w-full p-2 border rounded" />
         <textarea name="description" value={form.description} onChange={handleChange} placeholder="Printer Description" className="w-full p-2 border rounded" />
         <button type="submit" className="bg-blue-600 text-gray-900 dark:text-white px-4 py-2 rounded">Update Printer</button>
       </form>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -14,4 +14,6 @@ export interface Printer {
   is_available?: boolean
   is_deleted?: boolean
   is_under_maintenance?: boolean
+  min_runtime_hours?: number
+  max_runtime_hours?: number
 }

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "f383b9bf-6ff3-48cf-973e-309b88b78d89",
+    "title": "Custom Booking Runtime Limits",
+    "description": "- Added min and max runtime hours per printer.\n- Booking form enforces these limits.",
+    "created_at": "2025-06-19T00:00:00.000Z"
+  },
+  {
     "id": "05a8860e-aa28-43a0-949e-b2456483874c",
     "title": "Printer Maintenance Mode",
     "description": "- Owners can mark printers as under maintenance.\n- Bookings are blocked when a printer is under maintenance.\n- Maintenance status is shown on printer pages.",

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -16,6 +16,8 @@ create table if not exists bookings (
 alter table printers add column if not exists is_available boolean default true;
 alter table printers add column if not exists is_deleted boolean default false;
 alter table printers add column if not exists is_under_maintenance boolean default false;
+alter table printers add column if not exists min_runtime_hours numeric default 1;
+alter table printers add column if not exists max_runtime_hours numeric default 24;
 
 -- Patch Notes Table
 create table if not exists patch_notes (


### PR DESCRIPTION
## Summary
- allow printers to define `min_runtime_hours` and `max_runtime_hours`
- let owners edit runtime limits
- validate booking runtime against limits
- document changes in patch notes

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850ce81b1bc833397fe8ff05c9b01f8