### PR TITLE
Implement booking change request feature

### DIFF
--- a/__tests__/request-change.test.ts
+++ b/__tests__/request-change.test.ts
@@ -1,0 +1,41 @@
+import { POST } from '../app/api/bookings/request-change/route'
+import { createClient } from '../lib/supabase/server'
+
+jest.mock('../lib/supabase/server')
+
+describe('booking change request API', () => {
+  const mockInsert = jest.fn()
+  const mockFrom = jest.fn(() => ({ insert: mockInsert }))
+
+  beforeEach(() => {
+    ;(createClient as jest.Mock).mockReturnValue({ from: mockFrom })
+  })
+
+  it('inserts change request and returns success', async () => {
+    mockInsert.mockResolvedValue({ error: null })
+    const res = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ booking_id: '1', new_start_date: '2024', new_end_date: '2025', reason: 'test' }),
+      })
+    )
+    expect(mockFrom).toHaveBeenCalledWith('booking_change_requests')
+    expect(mockInsert).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('returns 500 on insert error', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'fail' } })
+    const res = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ booking_id: '1', new_start_date: '2024', new_end_date: '2025', reason: 'test' }),
+      })
+    )
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+})

--- a/app/api/bookings/request-change/route.ts
+++ b/app/api/bookings/request-change/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  const { booking_id, new_start_date, new_end_date, reason } = body
+
+  const supabase = createClient()
+  const { error } = await supabase.from('booking_change_requests').insert({
+    booking_id,
+    new_start_date,
+    new_end_date,
+    reason,
+  })
+
+  if (error) {
+    return NextResponse.json({ success: false, error }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -113,15 +113,34 @@ export default function BookingsPage() {
                   Cancel Booking
                 </button>
               )}
-              {new Date(booking.start_date) > new Date() &&
-                !['canceled', 'rejected'].includes(booking.status) && (
-                  <Link
-                    href={`/bookings/change/${booking.id}`}
-                    className="px-3 py-1 text-sm bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
-                  >
-                    Request Change
-                  </Link>
-                )}
+              {!['completed', 'canceled'].includes(booking.status) && (
+                <button
+                  onClick={async () => {
+                    const new_start = prompt('Enter new start date (YYYY-MM-DD):')
+                    const new_end = prompt('Enter new end date (YYYY-MM-DD):')
+                    const reason = prompt('Optional: Why are you requesting a change?')
+
+                    if (!new_start || !new_end) return
+
+                    const res = await fetch('/api/bookings/request-change', {
+                      method: 'POST',
+                      body: JSON.stringify({
+                        booking_id: booking.id,
+                        new_start_date: new_start,
+                        new_end_date: new_end,
+                        reason,
+                      }),
+                      headers: { 'Content-Type': 'application/json' },
+                    })
+
+                    if (res.ok) alert('Change request sent!')
+                    else alert('Something went wrong.')
+                  }}
+                  className="px-3 py-1 text-sm bg-green-600 hover:bg-green-700 text-gray-900 dark:text-white rounded"
+                >
+                  Request Change
+                </button>
+              )}
               {booking.status === 'canceled' && (
                 <button
                   onClick={() => deleteBooking(booking.id)}


### PR DESCRIPTION
## Summary
- add `/api/bookings/request-change` endpoint
- allow users to request booking changes directly from bookings list
- cover new API route with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850d8f04e0083339ee5af6fd63a3301