### PR TITLE
Add roadmap page and data

### DIFF
--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -1,0 +1,70 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+interface RoadmapItem {
+  title: string
+  description: string
+  status: 'planned' | 'in_progress' | 'done'
+  priority: 'low' | 'medium' | 'high'
+  tags?: string[]
+}
+
+function groupByStatus(items: RoadmapItem[]) {
+  return items.reduce<Record<RoadmapItem['status'], RoadmapItem[]>>(
+    (acc, item) => {
+      acc[item.status] = acc[item.status] ? [...acc[item.status], item] : [item]
+      return acc
+    },
+    { planned: [], in_progress: [], done: [] }
+  )
+}
+
+export default async function RoadmapPage() {
+  const filePath = path.join(process.cwd(), 'roadmap.json')
+  const file = await fs.readFile(filePath, 'utf-8')
+  const items: RoadmapItem[] = JSON.parse(file)
+  const groups = groupByStatus(items)
+
+  const statusLabels: Record<RoadmapItem['status'], string> = {
+    planned: 'Planned',
+    in_progress: 'In Progress',
+    done: 'Done',
+  }
+
+  return (
+    <main className="p-6 max-w-4xl mx-auto text-gray-900 dark:text-white">
+      <h1 className="text-3xl font-bold mb-6">🚧 Roadmap</h1>
+      {(Object.keys(groups) as RoadmapItem['status'][]).map(status => (
+        groups[status].length > 0 && (
+          <section key={status} className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">{statusLabels[status]}</h2>
+            {groups[status].map((item, idx) => (
+              <div
+                key={`${status}-${idx}`}
+                className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6 border border-gray-300 dark:border-gray-700"
+              >
+                <div className="text-xl font-semibold mb-2">{item.title}</div>
+                <p className="mb-2">{item.description}</p>
+                <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                  Priority: {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)}
+                </div>
+                {item.tags && item.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {item.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </section>
+        )
+      ))}
+    </main>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,6 +15,7 @@ export default function Navbar() {
         <Link href="/owner" className="text-gray-900 dark:text-white">Owner Panel</Link>
         <Link href="/my-printers" className="text-gray-900 dark:text-white">My Printers</Link>
         <Link href="/patch-notes" className="text-gray-900 dark:text-white">Patch Notes</Link>
+        <Link href="/roadmap" className="text-gray-900 dark:text-white">Roadmap</Link>
         <Link href="/profile" className="text-gray-900 dark:text-white">Profile</Link>
       </div>
       <div className="flex items-center gap-4">

--- a/roadmap.json
+++ b/roadmap.json
@@ -1,0 +1,9 @@
+[
+  {
+    "title": "Material Cost Integration",
+    "description": "Allow users to estimate material usage per booking and charge based on owner-defined cost per gram.",
+    "status": "planned",
+    "priority": "medium",
+    "tags": ["pricing", "owner-tools"]
+  }
+]


### PR DESCRIPTION
## Summary
- add roadmap JSON store
- render roadmap items grouped by status
- link to roadmap from the navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e095b22883339fc5c56054e4f58e