### PR TITLE
Update roadmap page to auto-complete

### DIFF
--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -20,10 +20,24 @@ function groupByStatus(items: RoadmapItem[]) {
 }
 
 export default async function RoadmapPage() {
-  const filePath = path.join(process.cwd(), 'roadmap.json')
-  const file = await fs.readFile(filePath, 'utf-8')
-  const items: RoadmapItem[] = JSON.parse(file)
-  const groups = groupByStatus(items)
+  const roadmapPath = path.join(process.cwd(), 'roadmap.json')
+  const notesPath = path.join(process.cwd(), 'patch_notes.json')
+
+  const [roadmapFile, notesFile] = await Promise.all([
+    fs.readFile(roadmapPath, 'utf-8'),
+    fs.readFile(notesPath, 'utf-8'),
+  ])
+
+  const items: RoadmapItem[] = JSON.parse(roadmapFile)
+  const notes: { title: string }[] = JSON.parse(notesFile)
+
+  const noteTitles = new Set(notes.map(n => n.title.toLowerCase()))
+
+  const updated = items.map(item =>
+    noteTitles.has(item.title.toLowerCase()) ? { ...item, status: 'done' } : item
+  )
+
+  const groups = groupByStatus(updated)
 
   const statusLabels: Record<RoadmapItem['status'], string> = {
     planned: 'Planned',


### PR DESCRIPTION
## Summary
- auto-set roadmap item status to `done` if there's a patch note with the same title
- show updated roadmap groups on the `/roadmap` page

## Testing
- `npm ci --ignore-scripts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e280adac83338fd07073c0ee2a14