### PR TITLE
Fix syntax error in roadmap page

### DIFF
--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -38,8 +38,6 @@ const updated: RoadmapItem[] = items.map(item =>
   noteTitles.has(item.title.toLowerCase()) ? { ...item, status: 'done' } : item
 )
 
-  )
-
   const groups = groupByStatus(updated)
 
   const statusLabels: Record<RoadmapItem['status'], string> = {


### PR DESCRIPTION
## Summary
- fix stray parenthesis in `app/roadmap/page.tsx`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850ec683ee88333b3f27272c2a20399