### PR TITLE
Fix file URL issue with spaces

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -90,7 +90,8 @@ export default function BookingPage() {
 
     if (file) {
       setUploading(true)
-      const path = `booking-files/${inserted.id}/${file.name}`
+      const safeName = encodeURIComponent(file.name)
+      const path = `booking-files/${inserted.id}/${safeName}`
       const { error: uploadError } = await supabase.storage
         .from('print-files')
         .upload(path, file)


### PR DESCRIPTION
## Summary
- encode uploaded file names before storing them in Supabase Storage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850f44943188333a2c97a70b7547564