### PR TITLE
Fix Supabase upload path

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -90,8 +90,7 @@ export default function BookingPage() {
 
     if (file) {
       setUploading(true)
-      const safeName = encodeURIComponent(file.name)
-      const path = `booking-files/${inserted.id}/${safeName}`
+      const path = `booking-files/${inserted.id}/${file.name}`
       const { error: uploadError } = await supabase.storage
         .from('print-files')
         .upload(path, file)


### PR DESCRIPTION
## Summary
- avoid double-encoding filenames when uploading to Storage

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68510be582ac8333a8300db617d7b51f