### PR TITLE
Add STL-first workflow

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -14,6 +14,10 @@ interface Booking {
   start_date: string
   end_date: string
   print_file_url?: string
+  layer_height?: string | null
+  infill?: string | null
+  supports?: boolean | null
+  print_notes?: string | null
   printers: { name: string; is_deleted?: boolean }
 }
 
@@ -114,7 +118,7 @@ export default function BookingsPage() {
                   Download Print File
                 </a>
               )}
-              {(['pending', 'approved'] as BookingStatus[]).includes(
+              {(['pending', 'awaiting_slice'] as BookingStatus[]).includes(
                 booking.status
               ) && (
                 <button
@@ -124,7 +128,12 @@ export default function BookingsPage() {
                   Cancel Booking
                 </button>
               )}
-              {!['completed', 'canceled'].includes(booking.status) && (
+              {![
+                'complete',
+                'canceled',
+                'ready_to_print',
+                'printing',
+              ].includes(booking.status) && (
                 <button
                   onClick={async () => {
                     const new_start = prompt('Enter new start date (YYYY-MM-DD):')

--- a/app/my-printers/page.tsx
+++ b/app/my-printers/page.tsx
@@ -39,7 +39,7 @@ export default function MyPrinters() {
         bookings?.forEach(b => {
           const start = new Date(b.start_date as string);
           const end = new Date(b.end_date as string);
-          if (b.status === 'approved' && start <= now && end >= now) {
+          if ((b.status === 'printing' || b.status === 'ready_to_print') && start <= now && end >= now) {
             map[b.printer_id as string] = true;
           }
         });

--- a/app/printers/[id]/page.tsx
+++ b/app/printers/[id]/page.tsx
@@ -30,11 +30,11 @@ export default function PrinterDetailPage() {
       for (const b of bookings || []) {
         const start = new Date(b.start_date);
         const end = new Date(b.end_date);
-        if (b.status === 'approved' && start <= now && end >= now) {
+        if ((b.status === 'printing' || b.status === 'ready_to_print') && start <= now && end >= now) {
           computedStatus = 'rented';
           break;
         }
-        if (b.status === 'pending' && start >= now) {
+        if ((b.status === 'pending' || b.status === 'awaiting_slice') && start >= now) {
           computedStatus = 'pending';
         }
       }

--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -29,7 +29,7 @@ export default function PrintersPage() {
         bookings?.forEach(b => {
           const start = new Date(b.start_date as string);
           const end = new Date(b.end_date as string);
-          if (b.status === 'approved' && start <= now && end >= now) {
+          if ((b.status === 'printing' || b.status === 'ready_to_print') && start <= now && end >= now) {
             map[b.printer_id as string] = true;
           }
         });

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,16 +1,16 @@
 export type BookingStatus =
   | 'pending'
-  | 'approved'
-  | 'rejected'
-  | 'in_progress'
-  | 'completed'
+  | 'awaiting_slice'
+  | 'ready_to_print'
+  | 'printing'
+  | 'complete'
   | 'canceled';
 
 export const bookingStatusClasses: Record<BookingStatus, string> = {
   pending: 'bg-yellow-400 text-black',
-  approved: 'bg-green-600 text-gray-900 dark:text-white',
-  rejected: 'bg-red-600 text-gray-900 dark:text-white',
-  in_progress: 'bg-blue-500 text-gray-900 dark:text-white',
-  completed: 'bg-blue-600 text-gray-900 dark:text-white',
+  awaiting_slice: 'bg-orange-500 text-gray-900 dark:text-white',
+  ready_to_print: 'bg-green-600 text-gray-900 dark:text-white',
+  printing: 'bg-blue-500 text-gray-900 dark:text-white',
+  complete: 'bg-blue-600 text-gray-900 dark:text-white',
   canceled: 'bg-red-600 text-gray-900 dark:text-white',
 };

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -71,4 +71,11 @@
     "description": "- Improved booking cancellation errors.\n- Cleaned duplicate components.\n- Clarified test instructions and fixed environment example.",
     "created_at": "2024-01-01T00:00:00.000Z"
   }
+  ,
+  {
+    "id": "2ed9d841-ecee-45c4-b689-b37c77cc762a",
+    "title": "STL-First Workflow",
+    "description": "- Added slicing preference fields to bookings.\n- Owners upload G-code and update status.\n- New status flow and owner panel section for awaiting_slice.",
+    "created_at": "2025-06-24T00:00:00.000Z"
+  }
 ]

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -9,11 +9,19 @@ create table if not exists bookings (
   estimated_runtime_hours numeric,
   actual_runtime_hours numeric,
   print_file_url text,
+  layer_height text,
+  infill text,
+  supports boolean,
+  print_notes text,
   status text default 'pending',
   created_at timestamp with time zone default now()
 );
 
 alter table bookings add column if not exists print_file_url text;
+alter table bookings add column if not exists layer_height text;
+alter table bookings add column if not exists infill text;
+alter table bookings add column if not exists supports boolean;
+alter table bookings add column if not exists print_notes text;
 
 -- Printers table update
 alter table printers add column if not exists is_available boolean default true;


### PR DESCRIPTION
## Summary
- allow slicer preferences on bookings
- implement awaiting_slice to ready_to_print flow
- update owner panel to handle STL-first slicing
- broaden printer availability checks
- document STL-first workflow in patch notes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851171e9e58833383dba546ee893d66