### PR TITLE
Add owner booking approval workflow

### DIFF
--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -4,7 +4,8 @@ export type BookingStatus =
   | 'ready_to_print'
   | 'printing'
   | 'complete'
-  | 'canceled';
+  | 'canceled'
+  | 'rejected';
 
 export const bookingStatusClasses: Record<BookingStatus, string> = {
   pending: 'bg-yellow-400 text-black',
@@ -13,4 +14,5 @@ export const bookingStatusClasses: Record<BookingStatus, string> = {
   printing: 'bg-blue-500 text-gray-900 dark:text-white',
   complete: 'bg-blue-600 text-gray-900 dark:text-white',
   canceled: 'bg-red-600 text-gray-900 dark:text-white',
+  rejected: 'bg-red-500 text-gray-900 dark:text-white',
 };

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -77,5 +77,11 @@
     "title": "STL-First Workflow",
     "description": "- Added slicing preference fields to bookings.\n- Owners upload G-code and update status.\n- New status flow and owner panel section for awaiting_slice.",
     "created_at": "2025-06-24T00:00:00.000Z"
+  },
+  {
+    "id": "3b67dc27-7ee5-4643-83a5-320fffc541dd",
+    "title": "Owner Panel Approvals",
+    "description": "- Manual booking approvals with Accept/Reject.\n- Awaiting Slice and Ready to Print sections.\n- Bookings grouped by status for easier management.",
+    "created_at": "2025-06-25T00:00:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- enable manual booking approval and rejection
- list bookings by status: pending, awaiting slice, ready to print, printing, complete, rejected
- upload sliced files and mark jobs ready
- show start/completion actions for ready/printing bookings
- document changes in patch notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511aca99488333bb3c6187f3bc938e