### PR TITLE
Fix change request button for rejected bookings

### DIFF
--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -133,6 +133,7 @@ export default function BookingsPage() {
                 'canceled',
                 'ready_to_print',
                 'printing',
+                'rejected',
               ].includes(booking.status) && (
                 <button
                   onClick={async () => {

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -154,12 +154,14 @@ export default function ProfilePage() {
                   )}
                   <p className="text-sm">Start: {start.toLocaleString()}</p>
                       <p className="text-sm">Duration: {hours} hrs</p>
-                      <Link
-                        href={`/bookings/change/${b.id}`}
-                        className="inline-block mt-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
-                      >
-                        Request Change
-                      </Link>
+                      {b.status !== 'rejected' && (
+                        <Link
+                          href={`/bookings/change/${b.id}`}
+                          className="inline-block mt-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+                        >
+                          Request Change
+                        </Link>
+                      )}
                     </li>
                   )
                 })}


### PR DESCRIPTION
## Summary
- hide Request Change button when booking status is `rejected`
- hide Request Change link on profile page if booking was rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851226f10dc8333887263bae775aa64