### PR TITLE
Fix change request button for rejected bookings

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -76,8 +76,7 @@ export default function BookingPage() {
     const ext = file?.name.split('.').pop()?.toLowerCase()
     let status: string = 'pending'
     if (file) {
-      if (ext === 'gcode') status = 'ready_to_print'
-      else if (
+      if (
         ext === 'stl' &&
         (layerHeight || infill || supports)
       )

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -133,6 +133,7 @@ export default function BookingsPage() {
                 'canceled',
                 'ready_to_print',
                 'printing',
+                'rejected',
               ].includes(booking.status) && (
                 <button
                   onClick={async () => {

--- a/app/patch-notes/page.tsx
+++ b/app/patch-notes/page.tsx
@@ -39,26 +39,30 @@ export default function PatchNotesPage() {
   return (
     <main className="p-6 max-w-4xl mx-auto text-gray-900 dark:text-white">
       <h1 className="text-3xl font-bold mb-6">📘 Patch Notes</h1>
-      {errorMsg && (
-        <p className="text-red-500 mb-4">{errorMsg}</p>
-      )}
-      {loading && (
-        <p className="mb-4">Loading patch notes…</p>
-      )}
+      {errorMsg && <p className="text-red-500 mb-4">{errorMsg}</p>}
+      {loading && <p className="mb-4">Loading patch notes…</p>}
       {!loading && notes.length === 0 && !errorMsg && (
         <p className="mb-4">No patch notes available.</p>
       )}
       {notes.map(note => (
-        <div
+        <details
           key={note.id}
-          className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6 border border-gray-300 dark:border-gray-700"
+          className="mb-4 border border-gray-300 dark:border-gray-700 rounded-lg"
         >
-          <div className="text-xl font-semibold">{note.title}</div>
-          <div className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-            {new Date(note.created_at).toLocaleString()}
+          <summary className="cursor-pointer select-none bg-gray-100 dark:bg-gray-700 px-4 py-2 font-medium flex justify-between items-center">
+            <span>{note.title}</span>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {new Date(note.created_at).toLocaleDateString()}
+            </span>
+          </summary>
+          <div className="px-4 py-2 bg-white dark:bg-gray-800">
+            {note.description.split('\n').map((line, idx) => (
+              <p key={idx} className="mb-2 last:mb-0">
+                {line}
+              </p>
+            ))}
           </div>
-          <p>{note.description}</p>
-        </div>
+        </details>
       ))}
     </main>
   )

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -154,12 +154,14 @@ export default function ProfilePage() {
                   )}
                   <p className="text-sm">Start: {start.toLocaleString()}</p>
                       <p className="text-sm">Duration: {hours} hrs</p>
-                      <Link
-                        href={`/bookings/change/${b.id}`}
-                        className="inline-block mt-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
-                      >
-                        Request Change
-                      </Link>
+                      {b.status !== 'rejected' && (
+                        <Link
+                          href={`/bookings/change/${b.id}`}
+                          className="inline-block mt-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded"
+                        >
+                          Request Change
+                        </Link>
+                      )}
                     </li>
                   )
                 })}

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -58,33 +58,37 @@ const updated: RoadmapItem[] = items.map(item =>
       <h1 className="text-3xl font-bold mb-6">🚧 Roadmap</h1>
       {statusOrder.map(status => (
         groups[status].length > 0 && (
-          <section key={status} className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">{statusLabels[status]}</h2>
-            {groups[status].map((item, idx) => (
-              <div
-                key={`${status}-${idx}`}
-                className="bg-white dark:bg-gray-800 rounded-2xl shadow p-6 mb-6 border border-gray-300 dark:border-gray-700"
-              >
-                <div className="text-xl font-semibold mb-2">{item.title}</div>
-                <p className="mb-2">{item.description}</p>
-                <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                  Priority: {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)}
-                </div>
-                {item.tags && item.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {item.tags.map(tag => (
-                      <span
-                        key={tag}
-                        className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded"
-                      >
-                        {tag}
-                      </span>
-                    ))}
+          <details key={status} className="mb-6" open={status !== 'done'}>
+            <summary className="cursor-pointer select-none bg-gray-100 dark:bg-gray-700 px-4 py-2 rounded text-xl font-semibold">
+              {statusLabels[status]}
+            </summary>
+            <div className="mt-4 space-y-4">
+              {groups[status].map((item, idx) => (
+                <div
+                  key={`${status}-${idx}`}
+                  className="bg-white dark:bg-gray-800 rounded-2xl shadow p-4 border border-gray-300 dark:border-gray-700"
+                >
+                  <div className="font-semibold mb-1">{item.title}</div>
+                  <p className="mb-2 text-sm">{item.description}</p>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                    Priority: {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)}
                   </div>
-                )}
-              </div>
-            ))}
-          </section>
+                  {item.tags && item.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {item.tags.map(tag => (
+                        <span
+                          key={tag}
+                          className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </details>
         )
       ))}
     </main>

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -83,5 +83,11 @@
     "title": "Owner Panel Approvals",
     "description": "- Manual booking approvals with Accept/Reject.\n- Awaiting Slice and Ready to Print sections.\n- Bookings grouped by status for easier management.",
     "created_at": "2025-06-25T00:00:00.000Z"
+  },
+  {
+    "id": "66394a65-b709-4d97-93bd-b4e626f4e3d7",
+    "title": "G-code Approval Workflow",
+    "description": "- G-code uploads no longer auto-mark bookings as ready.\n- Owners must approve before jobs move to Ready to Print.",
+    "created_at": "2025-06-26T00:00:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- hide Request Change button when booking status is `rejected`
- hide Request Change link on profile page if booking was rejected
- require owner approval before G-code bookings become ready to print
- document the G-code approval workflow
- redesign patch notes and roadmap pages

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6851226f10dc8333887263bae775aa64