### PR TITLE
Fix hero background gradient disappearing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
-        className="relative py-12 md:py-20"
+        className="relative z-0 py-12 md:py-20"
       >
         <div className="absolute inset-0 -z-10 overflow-hidden rounded-lg">
           <motion.div


### PR DESCRIPTION
## Summary
- ensure hero section establishes a stacking context so its gradient background remains visible

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f699b5288333a0f498744c687926