### PR TITLE
Fix mobile UI sidebar and hero layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Printer, User, UploadCloud, Search, Star } from "lucide-react";
-import { IconCube3dSphere } from "@tabler/icons-react";
+import { IconPrinter } from "@tabler/icons-react";
 
 
 
@@ -26,7 +26,7 @@ export default function Home() {
           />
         </div>
         <div className="grid md:grid-cols-2 gap-y-8 gap-x-8 md:gap-x-12 items-center">
-          <div className="space-y-6 text-center md:text-left px-4 md:px-12">
+          <div className="space-y-6 text-center md:text-left pl-6 pr-4 md:px-12">
             <h1 className="text-4xl md:text-5xl font-bold">
               Rent 3D Printers Near You — Fast, Flexible, On-Demand.
             </h1>
@@ -50,14 +50,14 @@ export default function Home() {
               </Link>
             </div>
           </div>
-          <div className="flex justify-center md:justify-end">
+          <div className="flex justify-center md:justify-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2, duration: 0.8 }}
-              className="w-64 h-64 md:w-80 md:h-80 flex items-center justify-center rounded-2xl shadow-xl"
+              className="w-64 h-64 md:w-80 md:h-80 flex items-center justify-center rounded-2xl shadow-xl mx-auto mt-8 md:mt-0"
             >
-              <IconCube3dSphere className="w-28 h-28 md:w-40 md:h-40 text-blue-400" />
+              <IconPrinter className="w-28 h-28 md:w-40 md:h-40 text-blue-400" />
             </motion.div>
           </div>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,10 +3,17 @@
 import Link from 'next/link';
 import ThemeToggle from '@/components/ThemeToggle';
 import AuthButtons from '@/components/AuthButtons';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (open) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+  }, [open]);
 
   return (
     <nav className="relative p-4 bg-gray-100 dark:bg-gray-900 border-b">
@@ -21,39 +28,27 @@ export default function Navbar() {
         >
           ☰
         </button>
+        {open && (
+          <div
+            className="fixed inset-0 bg-black/50 z-10 sm:hidden"
+            onClick={() => setOpen(false)}
+          />
+        )}
         <div
           className={`${
-            open ? 'flex' : 'hidden'
-          } sm:flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 absolute sm:static top-full left-0 w-full sm:w-auto bg-gray-100 dark:bg-gray-900 sm:bg-transparent sm:dark:bg-transparent p-4 sm:p-0 border-b sm:border-0`}
+            open ? 'translate-x-0' : '-translate-x-full'
+          } sm:translate-x-0 fixed sm:static inset-y-0 left-0 w-64 sm:w-auto bg-gray-100 dark:bg-gray-900 p-4 sm:p-0 flex flex-col sm:flex-row gap-4 z-20 transition-transform`}
         >
-          <Link href="/printers" className="text-gray-900 dark:text-white">
-            Printers
-          </Link>
-          <Link href="/printers/new" className="text-gray-900 dark:text-white">
-            New Listing
-          </Link>
-          <Link href="/bookings" className="text-gray-900 dark:text-white">
-            My Bookings
-          </Link>
-          <Link href="/owner" className="text-gray-900 dark:text-white">
-            Owner Panel
-          </Link>
-          <Link href="/my-printers" className="text-gray-900 dark:text-white">
-            My Printers
-          </Link>
-          <Link href="/patch-notes" className="text-gray-900 dark:text-white">
-            Patch Notes
-          </Link>
-          <Link href="/roadmap" className="text-gray-900 dark:text-white">
-            Roadmap
-          </Link>
-          <Link href="/profile" className="text-gray-900 dark:text-white">
-            Profile
-          </Link>
-          <div className="flex items-center gap-3 pt-2 sm:pt-0">
-            <ThemeToggle />
-            <AuthButtons />
-          </div>
+          <Link href="/printers">Printers</Link>
+          <Link href="/printers/new">New Listing</Link>
+          <Link href="/bookings">My Bookings</Link>
+          <Link href="/owner">Owner Panel</Link>
+          <Link href="/my-printers">My Printers</Link>
+          <Link href="/patch-notes">Patch Notes</Link>
+          <Link href="/roadmap">Roadmap</Link>
+          <Link href="/profile">Profile</Link>
+          <ThemeToggle />
+          <AuthButtons />
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- improve mobile sidebar experience with overlay and scroll lock
- center hero icon and swap in a printer icon
- tweak hero text padding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685205b035888333bd3fc9d89d193ea5