### PR TITLE
Implement printer tags and comparison features

### DIFF
--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -20,6 +20,7 @@ export default function BookingPage() {
   const [infill, setInfill] = useState('')
   const [supports, setSupports] = useState('')
   const [notes, setNotes] = useState('')
+  const [materialGrams, setMaterialGrams] = useState('')
 
   useEffect(() => {
     const fetchPrinter = async () => {
@@ -92,6 +93,7 @@ export default function BookingPage() {
         start_date: start.toISOString(),
         end_date: end.toISOString(),
         estimated_runtime_hours: runtime,
+        estimated_material_grams: materialGrams ? parseFloat(materialGrams) : null,
         layer_height: layerHeight || null,
         infill: infill || null,
         supports: supports ? supports === 'yes' : null,
@@ -191,8 +193,21 @@ export default function BookingPage() {
           } hours.`}
         </p>
         <p className="text-sm">
-          {`Estimated Cost: $${(runtime * (printer.price_per_hour || 0)).toFixed(2)}`}
+          {`Estimated Cost: $${(
+            runtime * (printer.price_per_hour || 0) +
+            (parseFloat(materialGrams) || 0) * (printer.cost_per_gram || 0)
+          ).toFixed(2)}`}
         </p>
+        <label className="block text-sm">
+          Estimated Material (g):
+          <input
+            type="number"
+            min="0"
+            value={materialGrams}
+            onChange={e => setMaterialGrams(e.target.value)}
+            className="mt-1 w-full p-2 border rounded text-black dark:text-white dark:bg-neutral-800"
+          />
+        </label>
         <label className="block text-sm">
           Optional Print File:
           <input

--- a/app/printers/compare/page.tsx
+++ b/app/printers/compare/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
+import type { Printer } from '@/lib/data'
+
+export default function ComparePrintersPage() {
+  const params = useSearchParams()
+  const ids = params.get('ids')?.split(',') ?? []
+  const [printers, setPrinters] = useState<Printer[]>([])
+
+  useEffect(() => {
+    const fetch = async () => {
+      if (ids.length === 0) return
+      const supabase = createPagesBrowserClient()
+      const { data } = await supabase
+        .from('printers')
+        .select('*')
+        .in('id', ids)
+      setPrinters(data || [])
+    }
+    fetch()
+  }, [ids])
+
+  if (ids.length === 0) return <p className="p-4">No printers selected.</p>
+
+  return (
+    <div className="p-4 overflow-auto">
+      <h1 className="text-2xl font-bold mb-4">Printer Comparison</h1>
+      <table className="min-w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">Feature</th>
+            {printers.map(p => (
+              <th key={p.id} className="border px-2 py-1">{p.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-2 py-1">Price/hr</td>
+            {printers.map(p => (
+              <td key={p.id} className="border px-2 py-1">${p.price_per_hour}</td>
+            ))}
+          </tr>
+          <tr>
+            <td className="border px-2 py-1">Materials</td>
+            {printers.map(p => (
+              <td key={p.id} className="border px-2 py-1">{p.materials?.join(', ')}</td>
+            ))}
+          </tr>
+          <tr>
+            <td className="border px-2 py-1">Build Volume</td>
+            {printers.map(p => (
+              <td key={p.id} className="border px-2 py-1">{p.build_volume}</td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/printers/new/page.tsx
+++ b/app/printers/new/page.tsx
@@ -13,6 +13,8 @@ export default function NewPrinterPage() {
     materials: '',
     build_volume: '',
     price_per_hour: '',
+    cost_per_gram: '',
+    tags: '',
     description: '',
   });
   const [status, setStatus] = useState('');
@@ -50,6 +52,11 @@ export default function NewPrinterPage() {
       materials: formData.materials.split(',').map(m => m.trim()),
       build_volume: formData.build_volume,
       price_per_hour: parseFloat(formData.price_per_hour),
+      cost_per_gram: parseFloat(formData.cost_per_gram) || 0,
+      tags: formData.tags
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean),
       description: formData.description || null,
       is_available: true,
     }]);
@@ -64,6 +71,8 @@ export default function NewPrinterPage() {
         materials: '',
         build_volume: '',
         price_per_hour: '',
+        cost_per_gram: '',
+        tags: '',
         description: '',
       });
     }
@@ -80,6 +89,8 @@ export default function NewPrinterPage() {
         <input name="materials" value={formData.materials} onChange={handleChange} placeholder="PLA, PETG, ABS..." required className={inputClass} />
         <input name="build_volume" value={formData.build_volume} onChange={handleChange} placeholder="220x220x250mm" required className={inputClass} />
         <input name="price_per_hour" type="number" value={formData.price_per_hour} onChange={handleChange} placeholder="Price per hour (e.g. 5.00)" required className={inputClass} />
+        <input name="cost_per_gram" type="number" value={formData.cost_per_gram} onChange={handleChange} placeholder="Cost per gram (e.g. 0.05)" required className={inputClass} />
+        <input name="tags" value={formData.tags} onChange={handleChange} placeholder="Tags (comma separated)" className={inputClass} />
         <textarea name="description" value={formData.description} onChange={handleChange} placeholder="Printer details (optional)" className={inputClass} />
         <button type="submit" className="bg-blue-600 text-gray-900 dark:text-white px-4 py-2 rounded">Submit</button>
         <p className="text-sm text-gray-600">{status}</p>

--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -3,11 +3,15 @@
 import { useEffect, useState } from 'react';
 import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
 import PrinterCard from '@/components/PrinterCard';
+import FilterButtons from '@/components/FilterButtons';
 import type { Printer } from '@/lib/data';
 
 export default function PrintersPage() {
   const [printers, setPrinters] = useState<Printer[]>([]);
   const [rented, setRented] = useState<Record<string, boolean>>({});
+  const [filter, setFilter] = useState('All');
+  const [compare, setCompare] = useState<Record<string, boolean>>({});
+  const [tags, setTags] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchPrinters = async () => {
@@ -18,6 +22,12 @@ export default function PrintersPage() {
         .eq('is_available', true)
         .eq('is_deleted', false);
       setPrinters(data || []);
+      setCompare({});
+      const tagSet = new Set<string>();
+      data?.forEach((p: any) => {
+        p.tags?.forEach((t: string) => tagSet.add(t));
+      });
+      setTags(['All', ...Array.from(tagSet)]);
       const ids = data?.map((p: any) => p.id) || [];
       if (ids.length > 0) {
         const { data: bookings } = await supabase
@@ -39,9 +49,14 @@ export default function PrintersPage() {
     fetchPrinters();
   }, []);
 
+  const filtered = printers.filter(p => filter === 'All' || p.tags?.includes(filter))
+
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">Available Printers</h2>
+      {tags.length > 1 && (
+        <FilterButtons filters={tags} currentFilter={filter} setFilter={setFilter} />
+      )}
       {printers.length === 0 ? (
         <div className="text-center mt-10 text-gray-400 flex flex-col items-center">
           <span className="text-6xl mb-2">🖨️</span>
@@ -49,9 +64,16 @@ export default function PrintersPage() {
         </div>
       ) : (
         <div className="flex flex-col gap-4 items-start">
-          {printers.map(printer => (
+          {filtered.map(printer => (
             <div key={printer.id} className="relative">
-              <PrinterCard printer={printer} />
+              <PrinterCard
+                printer={printer}
+                selectable
+                selected={!!compare[printer.id]}
+                onSelectChange={checked =>
+                  setCompare({ ...compare, [printer.id]: checked })
+                }
+              />
               {rented[printer.id] && (
                 <span className="absolute inset-0 bg-black/50 text-white flex items-center justify-center font-semibold pointer-events-none rounded">
                   Currently Rented
@@ -59,6 +81,16 @@ export default function PrintersPage() {
               )}
             </div>
           ))}
+          {Object.keys(compare).filter(id => compare[id]).length > 1 && (
+            <a
+              href={`/printers/compare?ids=${Object.keys(compare)
+                .filter(id => compare[id])
+                .join(',')}`}
+              className="px-4 py-2 bg-blue-600 text-gray-900 dark:text-white rounded mt-2"
+            >
+              Compare Selected
+            </a>
+          )}
         </div>
       )}
     </div>

--- a/components/PrinterCard.tsx
+++ b/components/PrinterCard.tsx
@@ -2,12 +2,15 @@ import Link from 'next/link';
 import type { Printer } from '@/lib/data';
 
 interface Props {
-  printer: Printer;
-  onEdit?: (printer: Printer) => void;
-  onDelete?: (id: string) => void;
+  printer: Printer
+  onEdit?: (printer: Printer) => void
+  onDelete?: (id: string) => void
+  selectable?: boolean
+  selected?: boolean
+  onSelectChange?: (checked: boolean) => void
 }
 
-export default function PrinterCard({ printer, onEdit, onDelete }: Props) {
+export default function PrinterCard({ printer, onEdit, onDelete, selectable, selected, onSelectChange }: Props) {
   const statusColors = {
     available: 'bg-green-600',
     pending: 'bg-yellow-500',
@@ -15,7 +18,15 @@ export default function PrinterCard({ printer, onEdit, onDelete }: Props) {
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded border border-gray-300 dark:border-gray-700 p-4 space-y-2 w-full sm:w-fit">
+    <div className="bg-white dark:bg-gray-800 rounded border border-gray-300 dark:border-gray-700 p-4 space-y-2 w-full sm:w-fit relative">
+      {selectable && (
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={e => onSelectChange?.(e.target.checked)}
+          className="absolute top-2 right-2"
+        />
+      )}
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-1">
         <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
           {printer.make_model}
@@ -39,6 +50,15 @@ export default function PrinterCard({ printer, onEdit, onDelete }: Props) {
       <div className="text-sm text-gray-800 dark:text-gray-100">
         <span className="font-medium">Hourly Rate:</span> ${printer.price_per_hour}/hr
       </div>
+      {printer.tags && printer.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 text-xs pt-1">
+          {printer.tags.map(tag => (
+            <span key={tag} className="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-0.5 rounded">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
 
       <p className="text-sm text-gray-600 dark:text-gray-300 pt-2">
         {printer.description}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -9,7 +9,9 @@ export interface Printer {
   materials: string[]
   build_volume: string
   price_per_hour: number
+  cost_per_gram: number
   description: string | null
+  tags?: string[]
   status?: string
   is_available?: boolean
   is_deleted?: boolean

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -70,8 +70,7 @@
     "title": "Major Updates",
     "description": "- Improved booking cancellation errors.\n- Cleaned duplicate components.\n- Clarified test instructions and fixed environment example.",
     "created_at": "2024-01-01T00:00:00.000Z"
-  }
-  ,
+  },
   {
     "id": "2ed9d841-ecee-45c4-b689-b37c77cc762a",
     "title": "STL-First Workflow",
@@ -89,19 +88,23 @@
     "title": "G-code Approval Workflow",
     "description": "- G-code uploads no longer auto-mark bookings as ready.\n- Owners must approve before jobs move to Ready to Print.",
     "created_at": "2025-06-26T00:00:00.000Z"
-  }
-  ,
+  },
   {
     "id": "e4a89d89-6fb1-47c8-bf09-d0de196d9310",
     "title": "Homepage Redesign",
     "description": "- Updated landing page with new hero section and CTAs.\n- Added renter/owner guides and modern stepper.",
     "created_at": "2025-06-27T00:00:00.000Z"
-  }
-  ,
+  },
   {
     "id": "90ffb974-fec0-45ef-bb84-ade8bcff166b",
     "title": "Mobile Responsive Design",
     "description": "- Optimized navigation and key pages for screens under 640px.\n- Added collapsible menu and responsive layouts.",
     "created_at": "2025-06-28T00:00:00.000Z"
+  },
+  {
+    "id": "a2ffcfea-fe89-4d88-888a-604b836a867f",
+    "title": "Printer Tags and Comparison",
+    "description": "- Added cost per gram field and material cost estimates.\n- Owners can tag printers and renters can filter by tag.\n- Added multi-material capability tags.\n- Users can compare selected printers side-by-side.",
+    "created_at": "2025-06-29T00:00:00.000Z"
   }
 ]

--- a/roadmap.json
+++ b/roadmap.json
@@ -2,7 +2,7 @@
   {
     "title": "Material Cost Integration",
     "description": "Allow users to estimate material usage per booking and charge based on owner-defined cost per gram.",
-    "status": "planned",
+    "status": "done",
     "priority": "medium",
     "tags": [
       "pricing",
@@ -32,7 +32,7 @@
   {
     "title": "Printer Tags & Filtering",
     "description": "Let owners add tags to their printers (e.g. PLA, high-speed, multi-color) and allow users to filter results by tag.",
-    "status": "planned",
+    "status": "done",
     "priority": "medium",
     "tags": [
       "search",
@@ -53,7 +53,7 @@
   {
     "title": "Multi-Material Support Tags",
     "description": "Allow owners to tag printers with special capabilities like dual extrusion, resin printing, or multicolor support. Renters can filter by these tags.",
-    "status": "planned",
+    "status": "done",
     "priority": "medium",
     "tags": [
       "printer-features",
@@ -97,7 +97,7 @@
   {
     "title": "Printer Comparison Tool",
     "description": "Allow renters to compare multiple printer listings by price, rating, materials, and print volume in a side-by-side view.",
-    "status": "planned",
+    "status": "done",
     "priority": "low",
     "tags": [
       "search",
@@ -119,7 +119,7 @@
   {
     "title": "Mobile Version of the Website",
     "description": "Build a responsive mobile-friendly version of the RentAPrint platform. Prioritize accessibility and usability on screens smaller than 640px using Tailwind CSS utilities. Key pages like homepage, listings, bookings, profile, and owner panel should adapt smoothly to mobile devices.",
-    "status": "planned",
+    "status": "done",
     "priority": "high",
     "tags": [
       "mobile",
@@ -128,4 +128,3 @@
     ]
   }
 ]
-

--- a/types/schema.sql
+++ b/types/schema.sql
@@ -22,6 +22,7 @@ alter table bookings add column if not exists layer_height text;
 alter table bookings add column if not exists infill text;
 alter table bookings add column if not exists supports boolean;
 alter table bookings add column if not exists print_notes text;
+alter table bookings add column if not exists estimated_material_grams numeric;
 
 -- Printers table update
 alter table printers add column if not exists is_available boolean default true;
@@ -29,6 +30,8 @@ alter table printers add column if not exists is_deleted boolean default false;
 alter table printers add column if not exists is_under_maintenance boolean default false;
 alter table printers add column if not exists min_runtime_hours numeric default 1;
 alter table printers add column if not exists max_runtime_hours numeric default 24;
+alter table printers add column if not exists cost_per_gram numeric default 0;
+alter table printers add column if not exists tags text[];
 
 -- Patch Notes Table
 create table if not exists patch_notes (


### PR DESCRIPTION
## Summary
- add cost_per_gram and tags fields for printers
- let owners define material cost and tags when creating a printer
- estimate material cost when booking
- filter printers by tags and enable comparison page
- document new schema columns
- update roadmap and patch notes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68520a489cb08333b3140d3784cf6b41