### PR TITLE
Add admin panel

### DIFF
--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminBookingsPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Bookings</h1>
+      <p className="text-gray-500">Booking management coming soon.</p>
+    </div>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,33 @@
+import { auth, currentUser } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { userId } = await auth()
+  if (!userId) redirect('/')
+  const user = await currentUser()
+  const isAdmin =
+    user?.publicMetadata?.role === 'admin' ||
+    (Array.isArray(user?.publicMetadata?.roles) && user!.publicMetadata!.roles.includes('admin')) ||
+    user?.privateMetadata?.role === 'admin' ||
+    (Array.isArray(user?.privateMetadata?.roles) && user!.privateMetadata!.roles.includes('admin'))
+  if (!isAdmin) redirect('/')
+
+  return (
+    <div className="flex flex-col md:flex-row min-h-screen">
+      <aside className="w-full md:w-60 bg-gray-100 dark:bg-gray-800 p-4 space-y-2">
+        <h2 className="text-xl font-bold mb-4 text-gray-900 dark:text-white">Admin</h2>
+        <nav className="flex flex-col space-y-1">
+          <Link href="/admin">Overview</Link>
+          <Link href="/admin/users">Users</Link>
+          <Link href="/admin/printers">Printers</Link>
+          <Link href="/admin/bookings">Bookings</Link>
+          <Link href="/admin/system">System</Link>
+        </nav>
+      </aside>
+      <main className="flex-1 p-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,69 @@
+import { clerkClient } from '@clerk/nextjs/server'
+import { createClient } from '@/lib/supabase/server'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AdminOverview() {
+  const supabase = createClient()
+
+  const clerk = await clerkClient()
+  const userList = await clerk.users.getUserList({ limit: 1 })
+  const totalUsers = (userList as any).total_count ?? (userList as any).totalCount ?? userList.data.length
+
+  const { count: printerCount } = await supabase
+    .from('printers')
+    .select('id', { count: 'exact', head: true })
+    .eq('is_deleted', false)
+
+  const { count: bookingsCount } = await supabase
+    .from('bookings')
+    .select('id', { count: 'exact', head: true })
+
+  const { count: maintenanceCount } = await supabase
+    .from('printers')
+    .select('id', { count: 'exact', head: true })
+    .eq('is_under_maintenance', true)
+    .eq('is_deleted', false)
+
+  const { count: activeBookings } = await supabase
+    .from('bookings')
+    .select('id', { count: 'exact', head: true })
+    .in('status', ['pending', 'awaiting_slice', 'ready_to_print', 'printing'])
+
+  const maintenancePercent = printerCount ? Math.round(((maintenanceCount ?? 0) / printerCount) * 100) : 0
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Overview</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <p className="text-sm text-gray-500">Total Users</p>
+          <p className="text-2xl font-semibold">{totalUsers}</p>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <p className="text-sm text-gray-500">Total Printers</p>
+          <p className="text-2xl font-semibold">{printerCount ?? 0}</p>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <p className="text-sm text-gray-500">Total Bookings</p>
+          <p className="text-2xl font-semibold">{bookingsCount ?? 0}</p>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <p className="text-sm text-gray-500">% Printers in Maintenance</p>
+          <p className="text-2xl font-semibold">{maintenancePercent}%</p>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <p className="text-sm text-gray-500">Active Bookings</p>
+          <p className="text-2xl font-semibold">{activeBookings ?? 0}</p>
+        </div>
+      </div>
+
+      <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+        <h2 className="text-lg font-semibold mb-2">Netlify Usage</h2>
+        <p>Requests used: --</p>
+        <p>Function runtime used: --</p>
+        <p className="text-sm text-gray-500">Live data integration coming soon</p>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/printers/page.tsx
+++ b/app/admin/printers/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminPrintersPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Printers</h1>
+      <p className="text-gray-500">Printer management coming soon.</p>
+    </div>
+  )
+}

--- a/app/admin/system/page.tsx
+++ b/app/admin/system/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminSystemPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">System</h1>
+      <p className="text-gray-500">System settings coming soon.</p>
+    </div>
+  )
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminUsersPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Users</h1>
+      <p className="text-gray-500">User management coming soon.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Clerk-protected admin layout and overview
- show live stats using Supabase and Clerk
- add placeholder admin pages for users, printers, bookings and system

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68522fb847648333b0623826ce7d8544