### PR TITLE
Update admin auth to whitelist user IDs

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,15 +2,13 @@ import { auth, currentUser } from '@clerk/nextjs/server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 
+const ADMIN_IDS = ['user_2yOOenOqgctifQSGp9mkcogBJTy']
+
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const { userId } = await auth()
   if (!userId) redirect('/')
   const user = await currentUser()
-  const isAdmin =
-    user?.publicMetadata?.role === 'admin' ||
-    (Array.isArray(user?.publicMetadata?.roles) && user!.publicMetadata!.roles.includes('admin')) ||
-    user?.privateMetadata?.role === 'admin' ||
-    (Array.isArray(user?.privateMetadata?.roles) && user!.privateMetadata!.roles.includes('admin'))
+  const isAdmin = user && ADMIN_IDS.includes(user.id)
   if (!isAdmin) redirect('/')
 
   return (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,19 +1,24 @@
 'use client';
-import { useUser } from '@clerk/nextjs';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useUser } from '@clerk/nextjs'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+const ADMIN_IDS = ['user_2yOOenOqgctifQSGp9mkcogBJTy']
 
 export default function AdminPage() {
-  const { user, isLoaded } = useUser();
-  const router = useRouter();
+  const { user, isLoaded } = useUser()
+  const router = useRouter()
 
   useEffect(() => {
-    if (isLoaded && user?.publicMetadata?.role !== 'admin') {
-      router.push('/');
-    }
-  }, [isLoaded, user]);
+    if (!isLoaded) return
 
-  if (!isLoaded || user?.publicMetadata?.role !== 'admin') {
+    const isAdmin = user && ADMIN_IDS.includes(user.id)
+    if (!isAdmin) {
+      router.push('/')
+    }
+  }, [isLoaded, user])
+
+  if (!isLoaded || !user || !ADMIN_IDS.includes(user.id)) {
     return <p className="p-4">Redirecting...</p>
   }
 


### PR DESCRIPTION
## Summary
- simplify `/admin` auth by removing role checks
- whitelist Clerk user IDs for admin access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852385f96c08333afe1be9568d849d2