### PR TITLE
Fix live Netlify usage fetch

### DIFF
--- a/app/admin/system/page.tsx
+++ b/app/admin/system/page.tsx
@@ -1,70 +1,66 @@
-import Link from 'next/link'
-import { listAppRoutes } from '@/lib/listRoutes'
+import Link from "next/link";
+import { listAppRoutes } from "@/lib/listRoutes";
 
 function bytesToGB(bytes: number) {
-  return bytes / (1024 ** 3)
+  return bytes / 1024 ** 3;
 }
 
 function msToHours(ms: number) {
-  return ms / 1000 / 60 / 60
+  return ms / 1000 / 60 / 60;
 }
 
 type NetlifyUsage = {
-  functions_invocations_count: number
-  functions_execution_time_ms: number
-  bandwidth_used: number
-  build_minutes_used: number
-}
+  functions_invocations_count: number;
+  functions_execution_time_ms: number;
+  bandwidth_used: number;
+  build_minutes_used: number;
+};
 
 type NetlifySite = {
-  name: string
-  ssl_url: string
-}
+  name: string;
+  ssl_url: string;
+};
 
 async function fetchNetlifyUsage() {
-  const token = process.env.NETLIFY_TOKEN
-  if (!token) return null
-  try {
-    const res = await fetch(
-      'https://api.netlify.com/api/v1/accounts/bc8df2c4-2079-4bd4-9a0c-8fe07b5c62aa/usage',
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-      }
-    )
-    if (!res.ok) return null
-    return (await res.json()) as NetlifyUsage
-  } catch {
-    return null
-  }
+  const res = await fetch(
+    "https://api.netlify.com/api/v1/accounts/bc8df2c4-2079-4bd4-9a0c-8fe07b5c62aa/usage",
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NETLIFY_TOKEN}`,
+      },
+    },
+  );
+
+  if (!res.ok) throw new Error("Failed to fetch Netlify usage");
+
+  return (await res.json()) as NetlifyUsage;
 }
 
 async function fetchNetlifySite() {
-  const siteId = process.env.NETLIFY_SITE_ID
-  const token = process.env.NETLIFY_TOKEN
-  if (!siteId || !token) return null
+  const siteId = process.env.NETLIFY_SITE_ID;
+  const token = process.env.NETLIFY_TOKEN;
+  if (!siteId || !token) return null;
   try {
-    const res = await fetch(`https://api.netlify.com/api/v1/sites/${siteId}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-      })
-    if (!res.ok) return null
-    return (await res.json()) as NetlifySite
+    const res = await fetch(`https://api.netlify.com/api/v1/sites/${siteId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as NetlifySite;
   } catch {
-    return null
+    return null;
   }
 }
 
 export default async function AdminSystemPage() {
-  const usage = await fetchNetlifyUsage()
-  const site = await fetchNetlifySite()
-  const routes = await listAppRoutes()
+  const usage = await fetchNetlifyUsage();
+  const site = await fetchNetlifySite();
+  const routes = await listAppRoutes();
 
-  const functionInvocations = usage?.functions_invocations_count ?? 0
-  const functionRuntimeHours = msToHours(usage?.functions_execution_time_ms ?? 0)
-  const bandwidthGB = bytesToGB(usage?.bandwidth_used ?? 0)
-  const buildMinutes = usage?.build_minutes_used ?? 0
+  const functionInvocations = usage.functions_invocations_count;
+  const functionRuntimeHours = msToHours(usage.functions_execution_time_ms);
+  const bandwidthGB = bytesToGB(usage.bandwidth_used);
+  const buildMinutes = usage.build_minutes_used;
 
   return (
     <div className="space-y-8">
@@ -72,33 +68,34 @@ export default async function AdminSystemPage() {
         <h1 className="text-2xl font-bold mb-4">Netlify Usage</h1>
         {site && (
           <p className="mb-4">
-            <a href={site.ssl_url} className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">
+            <a
+              href={site.ssl_url}
+              className="text-blue-600 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {site.name}
             </a>
           </p>
         )}
-        {usage ? (
-          <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-            <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
-              <h2 className="font-semibold">Function Invocations</h2>
-              <p>{functionInvocations.toLocaleString()}</p>
-            </div>
-            <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
-              <h2 className="font-semibold">Function Runtime</h2>
-              <p>{functionRuntimeHours.toFixed(2)} hrs</p>
-            </div>
-            <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
-              <h2 className="font-semibold">Bandwidth Used</h2>
-              <p>{bandwidthGB.toFixed(2)} GB</p>
-            </div>
-            <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
-              <h2 className="font-semibold">Build Minutes</h2>
-              <p>{buildMinutes}</p>
-            </div>
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+          <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+            <h2 className="font-semibold">Function Invocations</h2>
+            <p>{functionInvocations.toLocaleString()}</p>
           </div>
-        ) : (
-          <p className="text-red-500">Netlify usage unavailable.</p>
-        )}
+          <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+            <h2 className="font-semibold">Function Runtime</h2>
+            <p>{functionRuntimeHours.toFixed(2)} hours</p>
+          </div>
+          <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+            <h2 className="font-semibold">Bandwidth Used</h2>
+            <p>{bandwidthGB.toFixed(2)} GB</p>
+          </div>
+          <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+            <h2 className="font-semibold">Build Minutes</h2>
+            <p>{buildMinutes.toFixed(1)}</p>
+          </div>
+        </div>
       </section>
 
       <section>
@@ -120,5 +117,5 @@ export default async function AdminSystemPage() {
         <p>NPM {process.versions.npm}</p>
       </section>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- fetch live Netlify usage stats with server-side token
- display usage stats without fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68533b2a894c83338f154c1c3bc92c0d