### PR TITLE
Toggle admin route list via env

### DIFF
--- a/app/admin/system/page.tsx
+++ b/app/admin/system/page.tsx
@@ -1,23 +1,26 @@
 import Link from "next/link";
 import { listAppRoutes } from "@/lib/listRoutes";
+import { useEffect, useState } from "react";
 
 export default async function AdminSystemPage() {
   const routes = await listAppRoutes();
 
   return (
     <div className="space-y-8">
-      <section>
-        <h2 className="text-xl font-bold mb-2">App Routes</h2>
-        <ul className="list-disc pl-6 space-y-1">
-          {routes.map((route) => (
-            <li key={route}>
-              <Link href={route} className="text-blue-600 hover:underline">
-                {route}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </section>
+      {process.env.NEXT_PUBLIC_SHOW_ADMIN_ROUTES === 'true' && (
+        <section>
+          <h2 className="text-xl font-bold mb-2">App Routes</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            {routes.map((route) => (
+              <li key={route}>
+                <Link href={route} className="text-blue-600 hover:underline">
+                  {route}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section>
         <h2 className="text-xl font-bold mb-2">Environment</h2>


### PR DESCRIPTION
## Summary
- enable runtime toggle for admin route list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685358a735748333b15db6ad8d07102f