### PR TITLE
Major menu redesign and owner updates

### DIFF
--- a/app/api/bookings/messages/[id]/route.ts
+++ b/app/api/bookings/messages/[id]/route.ts
@@ -1,0 +1,30 @@
+import { auth } from '@clerk/nextjs/server'
+import { createClient } from '@/lib/supabase/server'
+import { cookies } from 'next/headers'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('booking_messages')
+    .select('*')
+    .eq('booking_id', params.id)
+    .order('timestamp', { ascending: true })
+  if (error) return new Response('Failed', { status: 500 })
+  return Response.json(data)
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const { userId } = await auth()
+  if (!userId) return new Response('Unauthorized', { status: 401 })
+  const { message } = await req.json()
+  const supabase = createClient()
+  const { error } = await supabase.from('booking_messages').insert({
+    booking_id: params.id,
+    sender_id: userId,
+    message,
+  })
+  if (error) return new Response('Failed', { status: 500 })
+  return new Response('ok')
+}

--- a/app/bookings/[id]/page.tsx
+++ b/app/bookings/[id]/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+import { useEffect, useState, useMemo } from 'react'
+import { useParams } from 'next/navigation'
+import { useUser, SignedIn, SignedOut, RedirectToSignIn } from '@clerk/nextjs'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+
+interface Message {
+  id: string
+  sender_id: string
+  message: string
+  timestamp: string
+}
+
+interface Booking {
+  id: string
+  status: string
+  printers: { name: string } | { name: string }[]
+}
+
+export default function BookingDetailPage() {
+  const { id } = useParams()
+  const { user } = useUser()
+  const supabase = useMemo(() => createClientComponentClient(), [])
+
+  const [booking, setBooking] = useState<Booking | null>(null)
+  const [messages, setMessages] = useState<Message[]>([])
+  const [text, setText] = useState('')
+
+  const load = async () => {
+    const { data } = await supabase
+      .from('bookings')
+      .select('id,status,printers(name)')
+      .eq('id', id)
+      .single()
+    setBooking(data as Booking)
+
+    const res = await fetch(`/api/bookings/messages/${id}`)
+    if (res.ok) {
+      setMessages(await res.json())
+    }
+  }
+
+  useEffect(() => {
+    if (id) {
+      load()
+      const t = setInterval(load, 10000)
+      return () => clearInterval(t)
+    }
+  }, [id])
+
+  const send = async () => {
+    if (!text) return
+    await fetch(`/api/bookings/messages/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text }),
+    })
+    setText('')
+    load()
+  }
+
+  return (
+    <>
+      <SignedIn>
+        <main className="max-w-2xl mx-auto p-6 space-y-4 text-gray-900 dark:text-white">
+          {booking && (
+            <div className="space-y-1">
+              <h1 className="text-2xl font-bold">Booking {booking.id}</h1>
+              <p>Printer: {Array.isArray(booking.printers) ? booking.printers[0]?.name : booking.printers?.name}</p>
+              <p>Status: {booking.status}</p>
+            </div>
+          )}
+          <div className="border rounded p-4 space-y-3 max-h-96 overflow-y-auto bg-white dark:bg-gray-800">
+            {messages.map(m => (
+              <div key={m.id} className="text-sm">
+                <span className="font-semibold">{m.sender_id === user?.id ? 'You' : 'Them'}:</span> {m.message}
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={text}
+              onChange={e => setText(e.target.value)}
+              className="flex-grow p-2 border rounded text-black dark:text-white dark:bg-neutral-800"
+            />
+            <button onClick={send} className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-gray-900 dark:text-white rounded">
+              Send
+            </button>
+          </div>
+        </main>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  )
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../printers/compare/page'
+export { default } from '../printers/compare/page'

--- a/app/earnings/page.tsx
+++ b/app/earnings/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { useEffect, useState, useMemo } from 'react'
+import { SignedIn, SignedOut, RedirectToSignIn, useUser } from '@clerk/nextjs'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+
+interface Row {
+  printer: string
+  hours: number
+  rate: number
+  tip: number | null
+}
+
+export const metadata = { title: 'Earnings - RentAPrint' }
+
+export default function EarningsPage() {
+  const { user } = useUser()
+  const supabase = useMemo(() => createClientComponentClient(), [])
+  const [rows, setRows] = useState<Row[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from('bookings')
+        .select('estimated_runtime_hours, actual_runtime_hours, tip_amount, printers(name, price_per_hour)')
+        .eq('printers.clerk_user_id', user?.id)
+        .eq('status', 'complete')
+
+      const list: Row[] = []
+      data?.forEach(b => {
+        const runtime = b.actual_runtime_hours ?? b.estimated_runtime_hours ?? 0
+        const printerName = Array.isArray(b.printers) ? b.printers[0]?.name : b.printers?.name
+        const rate = Array.isArray(b.printers) ? b.printers[0]?.price_per_hour : b.printers?.price_per_hour
+        list.push({ printer: printerName || 'Printer', hours: Number(runtime), rate: Number(rate), tip: b.tip_amount })
+      })
+      setRows(list)
+      setLoading(false)
+    }
+    if (user?.id) load()
+  }, [user])
+
+  const total = rows.reduce((sum, r) => sum + r.hours * r.rate + (r.tip || 0), 0)
+
+  return (
+    <>
+      <SignedIn>
+        <main className="p-6 text-gray-900 dark:text-white space-y-4">
+          <h1 className="text-2xl font-bold">Earnings</h1>
+          {loading ? (
+            <p>Loading...</p>
+          ) : rows.length === 0 ? (
+            <p>No completed bookings yet.</p>
+          ) : (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Printer</th>
+                  <th className="p-2">Hours</th>
+                  <th className="p-2">Rate</th>
+                  <th className="p-2">Tip</th>
+                  <th className="p-2">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <tr key={i} className="border-t">
+                    <td className="p-2">{r.printer}</td>
+                    <td className="p-2">{r.hours}</td>
+                    <td className="p-2">${r.rate}</td>
+                    <td className="p-2">{r.tip ? `$${r.tip}` : '-'}</td>
+                    <td className="p-2">${(r.hours * r.rate + (r.tip || 0)).toFixed(2)}</td>
+                  </tr>
+                ))}
+                <tr className="border-t font-semibold">
+                  <td className="p-2" colSpan={4}>Total</td>
+                  <td className="p-2">${total.toFixed(2)}</td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+        </main>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  )
+}

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,15 @@
+export const metadata = { title: 'FAQ - RentAPrint' }
+
+export default function FAQPage() {
+  return (
+    <main className="prose dark:prose-invert max-w-2xl mx-auto p-6">
+      <h1>Frequently Asked Questions</h1>
+      <h2>What is RentAPrint?</h2>
+      <p>RentAPrint lets makers rent 3D printers by the hour and allows owners to earn from idle machines.</p>
+      <h2>How do bookings work?</h2>
+      <p>Choose a printer, select your runtime, and upload your STL. The owner approves and prints your job.</p>
+      <h2>Can I list my own printer?</h2>
+      <p>Absolutely! Visit the Owner Panel to add your printer and start accepting bookings.</p>
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import Navbar from "../components/Navbar";
+import Link from "next/link";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -11,15 +12,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
       <html lang="en" suppressHydrationWarning>
+        <head>
+          <meta name="description" content="Rent 3D printers near you" />
+          <meta property="og:title" content="RentAPrint" />
+          <meta property="og:description" content="Book printers or list your own" />
+        </head>
         <body className={inter.className}>
           <Providers>
             <Navbar />
             <main className="max-w-7xl mx-auto p-4">{children}</main>
-            <footer className="text-center text-sm text-gray-500 py-4">
-              Open source by RentAPrint. Powered by the community. Visit{' '}
-              <a href="https://rentaprint.net" className="underline">
-                rentaprint.net
-              </a>{' '}for the official version.
+            <footer className="text-center text-sm text-gray-500 py-4 space-y-2">
+              <p>
+                Open source by RentAPrint. Powered by the community. Visit{' '}
+                <a href="https://rentaprint.net" className="underline">rentaprint.net</a>{' '}for the official version.
+              </p>
+              <p>
+                <Link href="/terms" className="underline mr-2">Terms</Link>
+                <Link href="/privacy" className="underline">Privacy</Link>
+              </p>
             </footer>
           </Providers>
         </body>

--- a/app/owner/components/OwnerPanelClient.tsx
+++ b/app/owner/components/OwnerPanelClient.tsx
@@ -6,7 +6,9 @@ import { SignedIn, SignedOut, RedirectToSignIn, useUser } from '@clerk/nextjs'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import type { Printer } from '@/lib/data'
 import { bookingStatusClasses, type BookingStatus } from '@/lib/bookings'
+import dynamic from 'next/dynamic'
 
+const STLViewer = dynamic(() => import('@/components/STLViewer'), { ssr: false })
 interface Booking {
   id: string
   printer_id: string
@@ -283,6 +285,11 @@ export default function OwnerPanel() {
                 <a href={b.print_file_url} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 dark:text-blue-400 underline">
                   Download STL
                 </a>
+              )}
+              {b.print_file_url?.toLowerCase().endsWith('.stl') && (
+                <div className="mt-2 h-72">
+                  <STLViewer url={b.print_file_url} />
+                </div>
               )}
               <p className="text-sm">Layer Height: {b.layer_height || 'N/A'}</p>
               <p className="text-sm">Infill: {b.infill || 'N/A'}</p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,10 @@
+export const metadata = { title: 'Privacy - RentAPrint' }
+
+export default function PrivacyPage() {
+  return (
+    <main className="prose dark:prose-invert max-w-2xl mx-auto p-6">
+      <h1>Privacy Policy</h1>
+      <p>We respect your privacy and only store data needed to manage bookings.</p>
+    </main>
+  )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -98,6 +98,14 @@ export default function ProfilePage() {
             </div>
           </section>
 
+          {/* Referral Link */}
+          <section className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded shadow p-6 space-y-4">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Referral</h2>
+            {user && (
+              <p className="break-all">Share this link to invite friends: https://rentaprint.net/ref/{user.id}</p>
+            )}
+          </section>
+
           {/* Statistics Section */}
           <section className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded shadow p-6 space-y-4">
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Account Statistics</h2>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,10 @@
+export const metadata = { title: 'Terms - RentAPrint' }
+
+export default function TermsPage() {
+  return (
+    <main className="prose dark:prose-invert max-w-2xl mx-auto p-6">
+      <h1>Terms of Service</h1>
+      <p>Use of this platform is subject to our business source license and community guidelines.</p>
+    </main>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,75 +1,84 @@
-'use client';
-
-import Link from 'next/link';
-import ThemeToggle from '@/components/ThemeToggle';
-import AuthButtons from '@/components/AuthButtons';
-import { useState, useEffect } from 'react';
-import { usePathname } from 'next/navigation';
-import WhatsNewModal from '@/components/WhatsNewModal';
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useState } from 'react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import * as Dialog from '@radix-ui/react-dialog'
+import { Menu } from 'lucide-react'
+import ThemeToggle from '@/components/ThemeToggle'
+import AuthButtons from '@/components/AuthButtons'
+import WhatsNewModal from '@/components/WhatsNewModal'
+import { ownerNav, infoNav, mainNav } from '@/lib/navigation'
 
 export default function Navbar() {
-  const [open, setOpen] = useState(false);
-  const pathname = usePathname();
-  useEffect(() => {
-    if (open) {
-      document.body.classList.add('overflow-hidden');
-    } else {
-      document.body.classList.remove('overflow-hidden');
-    }
-  }, [open]);
+  const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+
+  const linkClass = (href: string) =>
+    `px-3 py-1 ${pathname === href ? 'underline font-semibold' : ''}`
 
   return (
-    <nav className="relative p-4 bg-gray-100 dark:bg-gray-900 border-b">
+    <nav className="border-b bg-gray-100 dark:bg-gray-900 p-4">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <Link href="/" className="font-bold text-lg text-gray-900 dark:text-white">
           RentAPrint
         </Link>
-        <button
-          onClick={() => setOpen(!open)}
-          className="sm:hidden p-2 rounded border text-gray-900 dark:text-white"
-          aria-label="Toggle menu"
-        >
-          ☰
-        </button>
-        {open && (
-          <div
-            className="fixed inset-0 bg-black/50 z-10 sm:hidden"
-            onClick={() => setOpen(false)}
-          />
-        )}
-        <div
-          className={`${
-            open ? 'translate-x-0' : '-translate-x-full'
-          } sm:translate-x-0 fixed sm:static inset-y-0 left-0 w-64 sm:w-auto bg-gray-100 dark:bg-gray-900 p-4 sm:p-0 flex flex-col sm:flex-row gap-4 z-20 transition-transform`}
-        >
-          {[
-            { href: '/printers', label: 'Printers' },
-            { href: '/printers/new', label: 'New Listing' },
-            { href: '/bookings', label: 'My Bookings' },
-            { href: '/owner', label: 'Owner Panel' },
-            { href: '/my-printers', label: 'My Printers' },
-            { href: '/marketplace', label: 'Marketplace' },
-            { href: '/patch-notes', label: 'Patch Notes' },
-            { href: '/roadmap', label: 'Roadmap' },
-            { href: '/profile', label: 'Profile' },
-          ].map(link => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={
-                pathname === link.href
-                  ? 'font-semibold underline'
-                  : undefined
-              }
-            >
-              {link.label}
+        <div className="hidden sm:flex items-center gap-4">
+          {mainNav.map(n => (
+            <Link key={n.href} href={n.href} className={linkClass(n.href)}>
+              {n.label}
             </Link>
           ))}
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="px-3 py-1">Owner</DropdownMenu.Trigger>
+            <DropdownMenu.Content className="bg-white dark:bg-gray-800 shadow rounded p-2">
+              {ownerNav.map(n => (
+                <DropdownMenu.Item key={n.href} asChild>
+                  <Link href={n.href} className={linkClass(n.href)}>
+                    {n.label}
+                  </Link>
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="px-3 py-1">Info</DropdownMenu.Trigger>
+            <DropdownMenu.Content className="bg-white dark:bg-gray-800 shadow rounded p-2">
+              {infoNav.map(n => (
+                <DropdownMenu.Item key={n.href} asChild>
+                  <Link href={n.href} className={linkClass(n.href)}>
+                    {n.label}
+                  </Link>
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
           <WhatsNewModal />
           <ThemeToggle />
           <AuthButtons />
         </div>
+        <div className="sm:hidden">
+          <Dialog.Root open={open} onOpenChange={setOpen}>
+            <Dialog.Trigger asChild>
+              <button aria-label="Open menu">
+                <Menu />
+              </button>
+            </Dialog.Trigger>
+            <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+            <Dialog.Content className="fixed top-0 left-0 w-64 h-full bg-gray-100 dark:bg-gray-900 p-4 flex flex-col gap-2">
+              {[...mainNav, ...ownerNav, ...infoNav].map(n => (
+                <Link key={n.href} href={n.href} onClick={() => setOpen(false)} className={linkClass(n.href)}>
+                  {n.label}
+                </Link>
+              ))}
+              <div className="mt-auto flex gap-2">
+                <ThemeToggle />
+                <AuthButtons />
+              </div>
+            </Dialog.Content>
+          </Dialog.Root>
+        </div>
       </div>
     </nav>
-  );
+  )
 }

--- a/components/STLViewer.tsx
+++ b/components/STLViewer.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { Suspense } from 'react'
+import { useLoader } from '@react-three/fiber'
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+
+function Model({ url }: { url: string }) {
+  const geom = useLoader(STLLoader, url)
+  return (
+    <mesh geometry={geom} scale={0.01}>
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  )
+}
+
+export default function STLViewer({ url }: { url: string }) {
+  return (
+    <Canvas style={{ height: 300 }}>
+      <ambientLight intensity={0.5} />
+      <Suspense fallback={null}>
+        <Model url={url} />
+        <OrbitControls />
+      </Suspense>
+    </Canvas>
+  )
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,24 @@
+export interface NavItem {
+  href: string
+  label: string
+}
+
+export const ownerNav: NavItem[] = [
+  { href: '/owner', label: 'Owner Panel' },
+  { href: '/my-printers', label: 'My Printers' },
+  { href: '/bookings', label: 'Bookings' },
+  { href: '/earnings', label: 'Earnings' },
+]
+
+export const infoNav: NavItem[] = [
+  { href: '/patch-notes', label: 'Patch Notes' },
+  { href: '/roadmap', label: 'Roadmap' },
+  { href: '/faq', label: 'FAQ' },
+]
+
+export const mainNav: NavItem[] = [
+  { href: '/printers', label: 'Printers' },
+  { href: '/compare', label: 'Compare' },
+  { href: '/marketplace', label: 'Marketplace' },
+  { href: '/profile', label: 'Profile' },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@clerk/nextjs": "^6.21.0",
+        "@react-three/drei": "^9.56.0",
+        "@react-three/fiber": "^8.13.7",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.50.0",
         "@tabler/icons-react": "^3.34.0",
@@ -17,7 +19,8 @@
         "next": "^15.3.3",
         "next-themes": "^0.4.6",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "three": "^0.160.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.2.0",
@@ -533,7 +536,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3171,6 +3173,178 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.56.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.56.0.tgz",
+      "integrity": "sha512-8Gl8RjJN/ummQqgtzMOrcsWvnzDvvyQT0pWbrlSgIyN2GeIaGnMdVlr9ctW/XwA9Ds9wxLJUvciVorwzrl6YsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@react-spring/three": "^9.3.1",
+        "@use-gesture/react": "^10.2.0",
+        "camera-controls": "^1.38.0",
+        "detect-gpu": "^5.0.8",
+        "glsl-noise": "^0.0.0",
+        "lodash.clamp": "^4.0.3",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "maath": "^0.5.2",
+        "meshline": "^3.1.6",
+        "react-composer": "^5.0.3",
+        "react-merge-refs": "^1.1.0",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.0.8",
+        "three-mesh-bvh": "^0.5.22",
+        "three-stdlib": "^2.21.6",
+        "troika-three-text": "^0.47.1",
+        "utility-types": "^3.10.0",
+        "zustand": "^3.5.13"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.13.7",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.13.7.tgz",
+      "integrity": "sha512-fH1wYi8+A2YZX8uYd9N4hfbAV+kHE565s7f62+SMNmpeynaUsN8NzXACmmJ6BpVKAKdxfvOde6dBGwG1BrWOKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.1",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-gl": ">=11.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3450,18 +3624,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@testing-library/react/node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@testing-library/react/node_modules/@types/react-dom": {
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
@@ -3563,6 +3725,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3645,28 +3813,34 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3674,6 +3848,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -3977,6 +4157,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -4323,6 +4521,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4511,6 +4718,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-1.38.2.tgz",
+      "integrity": "sha512-EfzbovxLssyWpJVG9uKcazSDDIEcd1hUsPhPF/OWWnICsKY9WbLY/2S4UPW73HHbvnVeR/Z9wsWaQKtANy/2Yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4999,6 +5215,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -5069,6 +5294,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5354,6 +5585,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -5652,6 +5889,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -6268,6 +6511,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -9622,11 +9886,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.clamp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
+      "integrity": "sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -9674,6 +9958,16 @@
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.5.3.tgz",
+      "integrity": "sha512-ut63A4zTd9abtpi+sOHW1fPWPtAFrjK0E17eAthx1k93W/T2cWLKV5oaswyotJVDvvW1EXSdokAqhK5KOu0Qdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
       }
     },
     "node_modules/make-dir": {
@@ -9746,6 +10040,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
       }
     },
     "node_modules/micromatch": {
@@ -10036,7 +10339,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10450,6 +10752,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -10487,6 +10795,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",
@@ -10538,6 +10863,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -10557,6 +10894,56 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -10621,6 +11008,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11039,6 +11435,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -11326,6 +11728,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.0.8.tgz",
+      "integrity": "sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
@@ -11513,6 +11924,38 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.24.tgz",
+      "integrity": "sha512-VTIgfjz8aFoPKTQoMIQQv9jJD4ybFRZuKKE1/kqy78FQcuHQ0+iIWv7C5cSb2inlvs7bNMVY3yRx3RXGZfrvzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.123.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.0.tgz",
+      "integrity": "sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11537,6 +11980,36 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.2.tgz",
+      "integrity": "sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.47.2",
+        "troika-worker-utils": "^0.47.2",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.47.2.tgz",
+      "integrity": "sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.47.2.tgz",
+      "integrity": "sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==",
       "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
@@ -11780,6 +12253,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -11811,6 +12293,17 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -12170,6 +12663,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.21.0",
+    "@react-three/drei": "^9.56.0",
+    "@react-three/fiber": "^8.13.7",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.50.0",
     "@tabler/icons-react": "^3.34.0",
@@ -19,7 +21,8 @@
     "next": "^15.3.3",
     "next-themes": "^0.4.6",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "three": "^0.160.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.2.0",

--- a/patch_notes.json
+++ b/patch_notes.json
@@ -112,5 +112,18 @@
     "title": "UI and Feature Update",
     "description": "- Added search and active nav highlighting.\n- Verified printer badge and tipping options.",
     "created_at": "2025-06-19T03:55:01.000Z"
+  },
+  {
+    "id": "f9361ace-6013-497b-a628-c8d470e2af47",
+    "title": "Major Platform Update",
+    "description": "- Responsive dropdown navigation with owner/info menus.\n- Added FAQ, terms, privacy and compare routes.\n- Booking chat table and tip field in database.\n- STL preview for bookings.",
+    "created_at": "2025-06-30T00:00:00.000Z"
+  }
+,
+  {
+    "id": "ce88b748-5d06-4cfe-6187-fdded21b17d7",
+    "title": "Owner Earnings and Chat",
+    "description": "- Added earnings page summarizing completed bookings.\n- Booking detail chat with message threads.",
+    "created_at": "2025-07-01T00:00:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary
- switch navbar to dropdown menu with mobile sheet
- centralize nav links
- add FAQ, terms, privacy, compare and earnings pages
- STL preview in owner panel
- booking messages API and DB schema updates
- include footer links to terms and privacy
- add referral section on profile
- document latest patch notes
- add booking detail chat and owner earnings table
- remove favicon file reference

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853aa46a0ac83338eb25ce87c3ecfa2